### PR TITLE
Fix top-level domain in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vaccinate MA
 
-This is the application deployed to AWS Elastic Beanstalk for https://www.vaccinatema.org/. It is written in express.js and JavaScript.
+This is the application deployed to AWS Elastic Beanstalk for https://www.vaccinatema.com. It is written in express.js and JavaScript.
 
 ## Setup
 Get the AirTable API key from a team member and add it to your `.env` file.


### PR DESCRIPTION
In [issue #10](https://github.com/codeforboston/vaccinatema/issues/10), @tfmorris reported an issue with vaccinatema.**org** (rather than vaccinatema.**com**). I suspect they found the incorrect link in the README, as I did.