### PR TITLE
Add details about process in the FAQ

### DIFF
--- a/views/FAQ.ejs
+++ b/views/FAQ.ejs
@@ -63,12 +63,11 @@
   
       <div class="jumbotron">
         <h2>FAQ</h2>
-      <p>We are a group of volunteers including who want to help Massachusetts residents get vaccinated.</p>
+      <p>We are a group of volunteers helping Massachusetts residents get vaccinated. Our site uses a mix of automated and crowdsourced data to show vaccine appointment availabilty. VaccinateMA launched on January 17, 2021.</p>
 
       </div>
       <h3>Why are you doing this? Isn’t there a state site?</h3>
-      Massachusetts is ~40th out of 50 states in percentage of doses administered, <a href="https://www.nytimes.com/interactive/2020/us/covid-19-vaccine-doses.html" target="_blank"> according to the CDC. </a> The <a href="https://www.mass.gov/info-details/covid-19-vaccine-locations-for-individuals-in-phase-1#find-a-location-to-get-vaccinated-if-eligible-" target="_blank"> existing site </a> requires multiple click-throughs to find availability and doesn't allow easy nagivation via Google Maps. We want to make this process easier
-
+      Massachusetts is ~40th out of 50 states in percentage of doses administered, <a href="https://www.nytimes.com/interactive/2020/us/covid-19-vaccine-doses.html" target="_blank"> according to the CDC. </a> The <a href="https://www.mass.gov/info-details/covid-19-vaccine-locations-for-individuals-in-phase-1#find-a-location-to-get-vaccinated-if-eligible-" target="_blank"> existing site </a> requires multiple click-throughs to find availability and doesn't allow easy nagivation via Google Maps. We want to make this process easier.
       <h3>What if I want to help?</h3>
       Shoot us an email at <a href="mailto:vaccinatema@gmail.com" target="_blank"> vaccinatema@gmail.com </a>
       <h3>What if I’m a reporter and I want to contact you?</h3>


### PR DESCRIPTION
Added some details in the jumbotron on the "Who We Are" page

<img width="1101" alt="Screen Shot 2021-02-08 at 9 30 00 AM" src="https://user-images.githubusercontent.com/8596191/107233151-41169a80-69f0-11eb-9fe0-a3b130eb4f79.png">

