### PR TITLE
Remove maxRecords field when grabbing sites for map

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,6 @@ if (cluster.isMaster) {
         available = []
         base('MaVaccSites_Today').select({
             // Selecting the first 3 records in Grid view:
-            maxRecords: 120,
             view: "Default all site view"
         }).eachPage(function page(records, fetchNextPage) {
             // This function (`page`) will get called for each page of records.


### PR DESCRIPTION
It is optional and was previously hardcoded to an outdated value. This now shows all the sites from the backend on our front page map.