### PR TITLE
Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Thumbs.db
 *.wmv
 
 .elasticbeanstalk/*
+
+# Local environment
+.env


### PR DESCRIPTION
I believe we want `.env.template` checked in, but not `.env` so that we can put secrets in it (like the Airtable API key).

### Test Plan:
* Create a `.env` file.
* Run `git status` and see no new files!