### PR TITLE
add titles to pages

### DIFF
--- a/views/FAQ.ejs
+++ b/views/FAQ.ejs
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="A site to help Massachusetts residents find a vaccine">
     <meta name="author" content="MA Volunteers">
-    <meta property="og:title" content="COVID-19 Vaccine FAQ" />
+    <meta property="og:title" content="Help people get vaccinated for COVID-19" />
     <link rel="shortcut icon" type="image/x-icon" href="ma_logo.png" />
     <meta property="og:image" content="ma_logo.png"/>
 
-    <title>COVID-19 FAQs</title>
+    <title>Get Involved</title>
 
     <!-- Bootstrap core CSS -->
     <link href="<%= static_path + "/bootstrap/css/theme/" + theme + "/bootstrap.css" %>" rel="stylesheet">

--- a/views/FAQ.ejs
+++ b/views/FAQ.ejs
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="A site to help Massachusetts residents find a vaccine">
     <meta name="author" content="MA Volunteers">
+    <meta property="og:title" content="COVID-19 Vaccine FAQ" />
     <link rel="shortcut icon" type="image/x-icon" href="ma_logo.png" />
-    <meta property="og:title" content="Helping Massachusetts residents get vaccinated" />
     <meta property="og:image" content="ma_logo.png"/>
 
-    <title>Vaccinate MA</title>
+    <title>COVID-19 FAQs</title>
 
     <!-- Bootstrap core CSS -->
     <link href="<%= static_path + "/bootstrap/css/theme/" + theme + "/bootstrap.css" %>" rel="stylesheet">

--- a/views/eligibility.ejs
+++ b/views/eligibility.ejs
@@ -6,10 +6,10 @@
     <meta name="description" content="A site to help Massachusetts residents find a vaccine">
     <meta name="author" content="MA Volunteers">
     <link rel="shortcut icon" type="image/x-icon" href="ma_logo.png" />
-    <meta property="og:title" content="Helping Massachusetts residents get vaccinated" />
+    <meta property="og:title" content="COVID-19 Vaccine Eligibility" />
     <meta property="og:image" content="ma_logo.png"/>
 
-    <title>Vaccinate MA</title>
+    <title>COVID-19 Eligibility</title>
 
     <!-- Bootstrap core CSS -->
     <link href="<%= static_path + "/bootstrap/css/theme/" + theme + "/bootstrap.css" %>" rel="stylesheet">

--- a/views/eligibility.ejs
+++ b/views/eligibility.ejs
@@ -9,7 +9,7 @@
     <meta property="og:title" content="COVID-19 Vaccine Eligibility" />
     <meta property="og:image" content="ma_logo.png"/>
 
-    <title>COVID-19 Eligibility</title>
+    <title>COVID-19 Vaccine Eligibility</title>
 
     <!-- Bootstrap core CSS -->
     <link href="<%= static_path + "/bootstrap/css/theme/" + theme + "/bootstrap.css" %>" rel="stylesheet">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -6,7 +6,7 @@
     <meta name="description" content="A site to help Massachusetts residents find a vaccine">
     <meta name="author" content="MA Volunteers">
     <link rel="shortcut icon" type="image/x-icon" href="ma_logo.png" />
-    <meta property="og:title" content="Helping Massachusetts residents get vaccinated" />
+    <meta property="og:title" content="COVID-19 Vaccine Availability" />
     <meta property="og:image" content="ma_logo.png"/>
 
 

--- a/views/search.ejs
+++ b/views/search.ejs
@@ -9,7 +9,7 @@
     <meta property="og:title" content="COVID-19 Vaccine Search" />
     <meta property="og:image" content="ma_logo.png"/>
 
-    <title>COVID-19 Site Search</title>
+    <title>COVID-19 Vaccine Search</title>
 
     <!-- Bootstrap core CSS -->
     <link href="<%= static_path + "/bootstrap/css/theme/" + theme + "/bootstrap.css" %>" rel="stylesheet">

--- a/views/search.ejs
+++ b/views/search.ejs
@@ -6,10 +6,10 @@
     <meta name="description" content="A site to help Massachusetts residents find a vaccine">
     <meta name="author" content="MA Volunteers">
     <link rel="shortcut icon" type="image/x-icon" href="ma_logo.png" />
-    <meta property="og:title" content="Helping Massachusetts residents get vaccinated" />
+    <meta property="og:title" content="COVID-19 Vaccine Search" />
     <meta property="og:image" content="ma_logo.png"/>
 
-    <title>Vaccinate MA</title>
+    <title>COVID-19 Site Search</title>
 
     <!-- Bootstrap core CSS -->
     <link href="<%= static_path + "/bootstrap/css/theme/" + theme + "/bootstrap.css" %>" rel="stylesheet">

--- a/views/sites.ejs
+++ b/views/sites.ejs
@@ -6,10 +6,10 @@
     <meta name="description" content="A site to help Massachusetts residents find a vaccine">
     <meta name="author" content="MA Volunteers">
     <link rel="shortcut icon" type="image/x-icon" href="ma_logo.png" />
-    <meta property="og:title" content="Helping Massachusetts residents get vaccinated" />
+    <meta property="og:title" content="COVID-19 Vaccine Sites" />
     <meta property="og:image" content="ma_logo.png"/>
 
-    <title>Vaccinate MA</title>
+    <title>COVID-19 Vaccination Sites</title>
 
     <!-- Bootstrap core CSS -->
     <link href="<%= static_path + "/bootstrap/css/theme/" + theme + "/bootstrap.css" %>" rel="stylesheet">


### PR DESCRIPTION
I am pretty inexperienced when it comes to seo, but not very much of our traffic is coming through search. Most of the traffic is coming from referrals and direct links. As far as I understand SEO we want to get our site linked on a bunch of sites; enable [robots.txt](https://github.com/codeforboston/vaccinatema/pull/21) and provide good titles that relate to COVID. If anyone has any other ideas happy to hear them.

<img width="1485" alt="Screen Shot 2021-02-10 at 7 43 45 PM" src="https://user-images.githubusercontent.com/6435295/107591562-ec824380-6bd8-11eb-9eab-99b5ee839b58.png">
<img width="1574" alt="Screen Shot 2021-02-10 at 7 43 53 PM" src="https://user-images.githubusercontent.com/6435295/107591564-ed1ada00-6bd8-11eb-9fdd-56920947943b.png">
<img width="1580" alt="Screen Shot 2021-02-10 at 7 43 57 PM" src="https://user-images.githubusercontent.com/6435295/107591565-ed1ada00-6bd8-11eb-857e-66b1e2917ded.png">
<img width="715" alt="Screen Shot 2021-02-10 at 7 46 45 PM" src="https://user-images.githubusercontent.com/6435295/107591566-ed1ada00-6bd8-11eb-9899-82afd28e110a.png">
