### PR TITLE
Handle missing AIRTABLE_API_KEY better

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ if (cluster.isMaster) {
     var Airtable = require('airtable');
     var base;
     if (process.env.AIRTABLE_API_KEY) {
-	base = new Airtable({apiKey: process.env.AIRTABLE_API_KEY}).base('applrO42eyJ3rUQyb');
+        base = new Airtable({apiKey: process.env.AIRTABLE_API_KEY}).base('applrO42eyJ3rUQyb');
     }
     var sites = []
     var sites_latitude = []

--- a/app.js
+++ b/app.js
@@ -31,6 +31,8 @@ if (cluster.isMaster) {
     var base;
     if (process.env.AIRTABLE_API_KEY) {
         base = new Airtable({apiKey: process.env.AIRTABLE_API_KEY}).base('applrO42eyJ3rUQyb');
+    } else {
+        console.error('AIRTABLE_API_KEY should be set in .env');
     }
     var sites = []
     var sites_latitude = []

--- a/app.js
+++ b/app.js
@@ -28,7 +28,10 @@ if (cluster.isMaster) {
 // Code to run if we're in a worker process
 } else {
     var Airtable = require('airtable');
-    var base = new Airtable({apiKey: process.env.AIRTABLE_API_KEY}).base('applrO42eyJ3rUQyb');
+    var base;
+    if (process.env.AIRTABLE_API_KEY) {
+	base = new Airtable({apiKey: process.env.AIRTABLE_API_KEY}).base('applrO42eyJ3rUQyb');
+    }
     var sites = []
     var sites_latitude = []
     var sites_longitude = []
@@ -66,8 +69,9 @@ if (cluster.isMaster) {
         });        
         setTimeout(saveState, 60000);
     }
-
-    saveState();
+    if (process.env.AIRTABLE_API_KEY) {
+       saveState();
+    }
 
     var AWS = require('aws-sdk');
     var express = require('express');


### PR DESCRIPTION
This enables people to try out the parts of the site that don't require access to Airtable, without having to ask for the API key.