### PR TITLE
Fix alignment in footer.

### DIFF
--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -1,1 +1,1 @@
-$logo-offset: 72px;
+$logo-offset: 82px;


### PR DESCRIPTION
Small fix to make sure the "Made by volunteers..." text aligns in the footer.

Before:
![Screen Shot 2021-02-16 at 8 57 51 PM](https://user-images.githubusercontent.com/8495791/108145728-ec32ee00-7099-11eb-8813-7124202f45dd.png)

After:
![Screen Shot 2021-02-16 at 8 57 14 PM](https://user-images.githubusercontent.com/8495791/108145709-e4734980-7099-11eb-9aa2-f28aa36f1c4b.png)

