### PR TITLE
Allow all crawlers to index the site in robots.txt

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,7 +95,7 @@ if (cluster.isMaster) {
 
         server.use('/robots.txt', function (req, res) {
             res.type('text/plain');
-            res.send('User-agent: *\nDisallow: /');
+            res.send('User-agent: *\nAllow: /');
         });
 
         server.get('/', function(req, res) {


### PR DESCRIPTION
If I understand [this](https://trello.com/c/FFEuONsX/56-fix-robotstxt) Trello card correctly, we want all crawlers to index our site. This change enables that by replacing "disallow" with "allow.