### PR TITLE
Add Natick Mall as a new mass vaccination site 

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -111,13 +111,18 @@
                                           "Boston: Fenway Park", 
                                           "Danvers: Doubletree Hotel", 
                                           "Springfield: Eastfield Mall",
-                                          "Dartmouth: Circuit City at Dartmouth Towne Center", 
-                                          "Lowell: Lowell General Hospital at Cross River Center"];
+                                          "Dartmouth: Former Circuit City", 
+                                          "Lowell: Lowell General Hospital at Cross River Center",
+                                          "Natick: Natick Mall"];
+            // String matching is messy... the first one should be standard now but just in case
+            const textForStatewideSite = ["All eligible people statewide",
+                                          "Eligible populations statewide"];
             const loc = element.fields['Location Name']?.trim();
+            const serves = element.fields['Serves']?.trim();
             if (massVaccinationSites.includes(loc)) {
               icon_logo = "<%= static_path + "/Red_Star.svg" %>"
               scale = 5
-            } else if (element.fields['Serves']?.trim() === "Eligible populations statewide") {
+            } else if (textForStatewideSite.includes(serves)) {
               icon_logo = "<%= static_path + "/Green_Star.png" %>"
               scale = 5
             } else {


### PR DESCRIPTION
This change adds the Natick Mall to our list of mass vax sites so it'll appear with a red star. 

Also fixes the name of Dartmouth site to align with state's naming.

Also allows us to be more generous in the way we match strings for non-local sites since there was a mix of text in the Airtable indicating either "eligible populations statewide" or "all eligible people statewide" for the green star meaning general vaccination site that's not restricted to certain towns/cities.