### PR TITLE
Allow Next.js to handle unspecified paths.

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,6 +82,7 @@ if (cluster.isMaster) {
 
     const dev = process.env.NODE_ENV !== 'production';
     const app = next({ dev });
+    const handle = app.getRequestHandler();
 
     AWS.config.region = process.env.REGION;
 
@@ -186,6 +187,8 @@ if (cluster.isMaster) {
         // THE API ROUTES WE HAVE DEFINED NEED TO BE ADDED HERE:
         const locationApi = require('./routes/locations');
         server.use('/locations', locationApi);
+
+        server.all('*', handle);
 
         // Start the server.
         var port = process.env.PORT || 3002;


### PR DESCRIPTION
This change fixes a 404 error that occurs when running the website in dev mode: `GET http://localhost:3002/_next/webpack-hmr?page=/dev 404 (Not Found)`.

### Test Plan:
* Start the website in dev mode (`node app.js`). Visit one of the `/dev` pages. See no 404 errors.
* Start the website in production mode. Ensure it works as usual!