### PR TITLE
Add Google Analytics to React site

### DIFF
--- a/components/Seo.js
+++ b/components/Seo.js
@@ -13,6 +13,23 @@ export default function SEO({ pageTitle }) {
             <link rel="shortcut icon" type="image/x-icon" href="ma_logo.png" />
             <meta property="og:title" content="Helping Massachusetts residents get vaccinated" />
             <meta property="og:image" content="ma_logo.png"/>
+
+            {/* Global site tag (gtag.js) - Google Analytics https://stackoverflow.com/a/62552263 */}
+            <script
+                async
+                src="https://www.googletagmanager.com/gtag/js?id=G-TPH643QYMP"
+            />
+
+            <script
+                dangerouslySetInnerHTML={{
+                    __html: `
+                            window.dataLayer = window.dataLayer || [];
+                            function gtag(){dataLayer.push(arguments);}
+                            gtag('js', new Date());
+                            gtag('config', 'G-TPH643QYMP');
+                        `,
+                }}
+            />
         </Head>
     );
 }


### PR DESCRIPTION
Google Analytics in React/Next.js

Test Plan:
- Navigate to each page on localhost in the dev site 5 times. For some pages (e.g. eligibility), only use the navbar link, instead of directly accessing the URL in the browser. Look at the realtime GA analytics and make sure the pages are coming up and with the number of hits expected.

Implementation Notes:

I ended up using https://stackoverflow.com/a/62552263 which assumes that we are using the standard Next.js router (we should be!).

There are abstraction libraries like react-ga, but for Next.js there are a couple options:

next-ga -- older method, the package maintainer recommends looking at the newer experimental method and copying the code manually into your project

https://github.com/vercel/next.js/tree/canary/packages/next-plugin-google-analytics -- newer method, but still experimental

The tutorials you see online are basically manual implementations of one or the other of the above methods.