### PR TITLE
Add prettierrc to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ static/_next/
 
 # Vscode files
 .vscode/
+
+# Prettier configuration file
+.prettierrc


### PR DESCRIPTION
I would love to introduce [Prettier](https://prettier.io/) to the codebase, but until we have that discussion, it'd be nice for individuals to be able to use it locally.

### Test Plan:
* Create a `.prettierrc` file.
* Run `git status` and see that it does not appear.