### PR TITLE
Ensure the search tab is highlighted on the correct page.

### DIFF
--- a/components/NavHeader.js
+++ b/components/NavHeader.js
@@ -27,7 +27,7 @@ const NavHeader = () => {
                     <Nav className="mr-auto"></Nav>
                     <Nav>
                         <Nav.Link
-                            className={renderLinkClass('home')}
+                            className={renderLinkClass('search')}
                             href={`${root}/search`}
                         >
                             Search


### PR DESCRIPTION
Before, "Search" (in the navbar) was getting highlighted when on the homepage.

### Test Plan:
* Navigate to `/dev`. See nothing highlighted in the navbar.
* Navigate to `/dev/search`. See "Search" highlighted in the navbar.