### PR TITLE
Added build step to README instruction for running server locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ open .env
 Then run the server locally.
 ```sh
 npm install
+npm run build
 npm run local
 open http://127.0.0.1:3002/
 ```


### PR DESCRIPTION
Added `npm run build` step in the README instructions for running server locally.