### PR TITLE
Ensure FontAwesomeIcon components respect font size.

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Seo from './Seo';
+import PageHead from './PageHead';
 import NavHeader from './NavHeader';
 import Footer from './Footer';
 
@@ -11,7 +11,7 @@ export default function Layout({
 }) {
     return (
         <div className="container">
-            <Seo pageTitle={pageTitle} />
+            <PageHead pageTitle={pageTitle} />
             <NavHeader />
             <div className="main-content">
                 {children}

--- a/components/PageHead.js
+++ b/components/PageHead.js
@@ -1,11 +1,17 @@
 import React from 'react';
 import Head from 'next/head';
 import PropTypes from 'prop-types';
+import {config, dom} from '@fortawesome/fontawesome-svg-core';
 
-export default function SEO({ pageTitle }) {
+// Work around for ReactFontAwesome loading large images before resizing.
+// See https://github.com/FortAwesome/react-fontawesome/issues/134
+config.autoAddCss = false;
+
+export default function PageHead({pageTitle}) {
     return (
         <html lang="en">
             <Head>
+                {/* Tags for SEO */}
                 <title>{`${pageTitle} | Vaccinate MA`}</title>
                 <meta charSet="utf-8" />
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -31,11 +37,14 @@ export default function SEO({ pageTitle }) {
                             `,
                     }}
                 />
+                {/* Work around for ReactFontAwesome not respecting font size.
+                See https://github.com/FortAwesome/react-fontawesome/issues/284 */}
+                <style>{dom.css()}</style>
             </Head>
         </html>
     );
 }
 
-SEO.propTypes = {
+PageHead.propTypes = {
     pageTitle: PropTypes.string,
 };

--- a/styles/_app.scss
+++ b/styles/_app.scss
@@ -133,9 +133,9 @@ a {
       position: relative;
       display: inline;
       left: $logo-offset;
+      font-size: 30px;
       svg {
         color: black;
-        height: 30px;
         margin-right: 10px;
       }
     }


### PR DESCRIPTION
I noticed that `FontAwesomeIcon` components weren't respecting the font size of their parent, as they should. Instead, we had to manually set heights or widths. I searched around a bit, and found a fix! This will be more important as we implement more of Harlan's designs.

![Screen Shot 2021-02-21 at 1 08 25 PM](https://user-images.githubusercontent.com/8495791/108634102-10018580-7446-11eb-8839-57320011c92e.png)
