### PR TITLE
Fixed infinite initmap load issue

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -153,7 +153,7 @@ const Map = ({height = '400px', width = '100%'}) => {
             .then(response => response.json())
             .then(siteData => parseLocationData(siteData))
             .then(siteData => setSiteData(siteData));
-    });
+    }, []); // empty array as 2nd param so that function runs only on initial page load
 
     return (
     // Container element must have height and width for map to display. See https://developers.google.com/maps/documentation/javascript/overview#Map_DOM_Elements


### PR DESCRIPTION
Homepage in React loads data from /initmap route, but useEffect hook is set up incorrectly and runs on every rerender instead of just when the page first loads. Added an empty array second parameter to the useEffect hook to fix the issue.

Tested locally -- without the fix, Chrome network tab shows infinite calls to /initmap. With the fix, Chrome network tab does not show these calls.