### PR TITLE
Allow searching by city or town

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,9 +111,9 @@ if (cluster.isMaster) {
             } else {
                 locations = sites;
             }
-            if (req.body.zipCode) {
-                const geo = geocoder({ key: process.env.GEOCODER_API_KEY});
-                geo.find(req.body.zipCode, function(geoErr, geoRes){
+            if (req.body.address) {
+                const geo = geocoder({ key: process.env.GEOCODER_API_KEY });
+                geo.find(req.body.address + ' Massachusetts', function(geoErr, geoRes){
                     const { lat, lng } = geoRes[0].location;
                     const closest = distanceUtils.getClosestLocations(
                         locations,

--- a/pages/search.js
+++ b/pages/search.js
@@ -6,7 +6,7 @@ import parseBookAppointmentString from '../components/utilities/parseBookAppoint
 class Search extends React.Component {
     constructor(props) {
         super(props);
-        this.siteDataResultsRef = React.createRef();  
+        this.siteDataResultsRef = React.createRef();
     }
 
     state = {
@@ -44,7 +44,7 @@ class Search extends React.Component {
     }
 
     getLatitudeAndLongitudeByGeolocation = () => {
-        return new Promise((resolve, reject) => 
+        return new Promise((resolve, reject) =>
             navigator.geolocation.getCurrentPosition(resolve, reject)
         );
     }
@@ -87,7 +87,16 @@ class Search extends React.Component {
     parseDate = dateString => (
         new Date(Date.parse(dateString)).toLocaleString('en-US', {timeZone: 'America/New_York'})
     )
-    
+
+    handleEnter = (event) => {
+        const { searchByAddress } = this;
+
+        if (event.keyCode === 13) {
+            // If a user presses Enter, trigger search
+            searchByAddress();
+        }
+    };
+
     renderSiteData = () => {
         const { siteData } = this.state;
 
@@ -112,8 +121,8 @@ class Search extends React.Component {
     };
 
     render() {
-        const { renderSiteData } = this;
-        
+        const { renderSiteData, handleEnter } = this;
+
         return (
             <Layout pageTitle="Search">
                 <div className= "jumbotron bg-white">
@@ -143,7 +152,17 @@ class Search extends React.Component {
                                 {this.state.geolocationError && <p>Cannot figure out your location.</p>}
                                 <div className="form-group">
                                     <label htmlFor="address">or near</label>
-                                    <input type="text" className="form-control" id="address" name="address" placeholder="City, town, or zip code" required="" value={this.state.address} onChange={this.handleChange} />
+                                    <input
+                                        type="text"
+                                        className="form-control"
+                                        id="address"
+                                        name="address"
+                                        placeholder="City, town, or zip code"
+                                        required=""
+                                        value={this.state.address}
+                                        onChange={this.handleChange}
+                                        onKeyDown={handleEnter}
+                                    />
                                 </div>
                                 {this.state.addressError && <p>City or zip code cannot be blank</p>}
                                 <button onClick={this.searchByAddress} id="signup" className="btn btn-primary">Search</button>

--- a/pages/search.js
+++ b/pages/search.js
@@ -11,26 +11,30 @@ class Search extends React.Component {
 
     state = {
         siteData: [],
-        zipCode: '',
+        address: '',
         availability: 'Sites with reported doses',
-        zipCodeError: false,
+        addressError: false,
         geolocationError: false
     }
 
     searchByZipCode = () => {
-        this.setState({zipCodeError: false, geolocationError: false});
-        if (/^\d{5}$/.test(this.state.zipCode)) {
-            this.getLocationData(null, null, this.state.availability, this.state.zipCode);
+        this.setState({addressError: false, geolocationError: false});
+        if (this.state.address) {
+            this.getLocationData({ availability: this.state.availability, address: this.state.address });
         } else {
-            this.setState({zipCodeError: true});
+            this.setState({addressError: true});
         }
     }
 
     searchByGeolocation = () => {
-        this.setState({zipCodeError: false, geolocationError: false});
+        this.setState({addressError: false, geolocationError: false});
         if ('geolocation' in navigator) {
             this.getLatitudeAndLongitudeByGeolocation()
-                .then(position => this.getLocationData(position.coords.latitude, position.coords.longitude, this.state.availability, null))
+                .then(position => this.getLocationData({
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    availability: this.state.availability
+                }))
                 .catch(error => {
                     console.error(error);
                 });
@@ -52,16 +56,11 @@ class Search extends React.Component {
         this.setState(newState);
     }
 
-    getLocationData = (latitude, longitude, availability, zipCode) => {
+    getLocationData = (args) => {
         return fetch('/search_query_location', {
             method: 'post',
             headers: new Headers({'content-type': 'application/json'}),
-            body: JSON.stringify({
-                latitude,
-                longitude,
-                availability,
-                zipCode
-            })
+            body: JSON.stringify({ ...args })
         })
             .then(response => response.json())
             .then(data => this.parseLocationData(data))
@@ -143,11 +142,11 @@ class Search extends React.Component {
                                 <button id="geolocate" onClick={this.searchByGeolocation} className="btn btn-primary">My Location</button>
                                 {this.state.geolocationError && <p>Cannot figure out your location.</p>}
                                 <div className="form-group">
-                                    <label htmlFor="zipCode">or near</label>
-                                    <input type="text" className="form-control" id="zipCode" name="zipCode" placeholder="5-digit zip code" required="" value={this.state.zipCode} onChange={this.handleChange} />
+                                    <label htmlFor="address">or near</label>
+                                    <input type="text" className="form-control" id="address" name="address" placeholder="city, town, or zip code" required="" value={this.state.address} onChange={this.handleChange} />
                                 </div>
-                                {this.state.zipCodeError && <p>Please enter a valid zip code!</p>}
-                                <button onClick={this.searchByZipCode} id="signup" className="btn btn-primary">Search By Zip Code</button>
+                                {this.state.addressError && <p>City or zip code cannot be blank</p>}
+                                <button onClick={this.searchByZipCode} id="signup" className="btn btn-primary">Search</button>
                             </div>
                         </div>
                     </div>

--- a/pages/search.js
+++ b/pages/search.js
@@ -17,7 +17,7 @@ class Search extends React.Component {
         geolocationError: false
     }
 
-    searchByZipCode = () => {
+    searchByAddress = () => {
         this.setState({addressError: false, geolocationError: false});
         if (this.state.address) {
             this.getLocationData({ availability: this.state.availability, address: this.state.address });
@@ -143,10 +143,10 @@ class Search extends React.Component {
                                 {this.state.geolocationError && <p>Cannot figure out your location.</p>}
                                 <div className="form-group">
                                     <label htmlFor="address">or near</label>
-                                    <input type="text" className="form-control" id="address" name="address" placeholder="city, town, or zip code" required="" value={this.state.address} onChange={this.handleChange} />
+                                    <input type="text" className="form-control" id="address" name="address" placeholder="City, town, or zip code" required="" value={this.state.address} onChange={this.handleChange} />
                                 </div>
                                 {this.state.addressError && <p>City or zip code cannot be blank</p>}
-                                <button onClick={this.searchByZipCode} id="signup" className="btn btn-primary">Search</button>
+                                <button onClick={this.searchByAddress} id="signup" className="btn btn-primary">Search</button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Allow searching by city or town.

Geocoder already supports searching by any part of an address.

The Geocoder has component filtering by country and locality (like zip code), but no hard filter exists for state.
Adding ' Massachusetts' to the end of the address string provides an adequate filter.

Proof of concept:
Before the add, searching "Lawrence" returns Lawrence Kansas. The returned search results are Lee, Pittsfield, and others in the western most part of the state.
After the add, searching "Lawrence" returns results in Haverhill and other sites near Lawrence Mass.

What if a user enters the state as well?
Tried entering towns plus "MA", "Mass", "Massachusetts", and spelling errors. The Geocoder seems very forgiving and the results were consistently good across several towns all over the state.