### PR TITLE
Add option to see all locations at once.

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,24 +111,27 @@ if (cluster.isMaster) {
             } else {
                 locations = sites;
             }
+            // TODO(hannah): Once there are enough results, we should switch to
+            // pagination.
+            const showAllResults = req.body.showAllResults;
             if (req.body.zipCode) {
                 const geo = geocoder({ key: process.env.GEOCODER_API_KEY});
                 geo.find(req.body.zipCode, function(geoErr, geoRes){
                     const { lat, lng } = geoRes[0].location;
                     const closest = distanceUtils.getClosestLocations(
                         locations,
-                        5,
                         lat,
-                        lng
+                        lng,
+                        showAllResults
                     );
                     res.send(closest);
                 });
             } else {
                 const closest = distanceUtils.getClosestLocations(
                     locations,
-                    5,
                     req.body.latitude,
-                    req.body.longitude
+                    req.body.longitude,
+                    showAllResults,
                 );
                 res.send(closest);
             }

--- a/pages/search.js
+++ b/pages/search.js
@@ -14,13 +14,20 @@ class Search extends React.Component {
         zipCode: '',
         availability: 'Sites with reported doses',
         zipCodeError: false,
-        geolocationError: false
+        geolocationError: false,
+        showAllResults: false,
     }
 
     searchByZipCode = () => {
         this.setState({zipCodeError: false, geolocationError: false});
         if (/^\d{5}$/.test(this.state.zipCode)) {
-            this.getLocationData(null, null, this.state.availability, this.state.zipCode);
+            this.getLocationData(
+                null,
+                null,
+                this.state.availability,
+                this.state.zipCode,
+                this.state.showAllResults
+            );
         } else {
             this.setState({zipCodeError: true});
         }
@@ -30,7 +37,15 @@ class Search extends React.Component {
         this.setState({zipCodeError: false, geolocationError: false});
         if ('geolocation' in navigator) {
             this.getLatitudeAndLongitudeByGeolocation()
-                .then(position => this.getLocationData(position.coords.latitude, position.coords.longitude, this.state.availability, null))
+                .then((position) =>
+                    this.getLocationData(
+                        position.coords.latitude,
+                        position.coords.longitude,
+                        this.state.availability,
+                        null,
+                        this.state.showAllResults,
+                    )
+                )
                 .catch(error => {
                     console.error(error);
                 });
@@ -52,7 +67,7 @@ class Search extends React.Component {
         this.setState(newState);
     }
 
-    getLocationData = (latitude, longitude, availability, zipCode) => {
+    getLocationData = (latitude, longitude, availability, zipCode, showAllResults) => {
         return fetch('/search_query_location', {
             method: 'post',
             headers: new Headers({'content-type': 'application/json'}),
@@ -60,7 +75,8 @@ class Search extends React.Component {
                 latitude,
                 longitude,
                 availability,
-                zipCode
+                zipCode,
+                showAllResults,
             })
         })
             .then(response => response.json())
@@ -112,6 +128,12 @@ class Search extends React.Component {
         }
     };
 
+    numResultsChanged = (e) => {
+        this.setState({
+            showAllResults: e.currentTarget.value === 'all',
+        });
+    };
+
     render() {
         const { renderSiteData } = this;
         
@@ -148,6 +170,28 @@ class Search extends React.Component {
                                 </div>
                                 {this.state.zipCodeError && <p>Please enter a valid zip code!</p>}
                                 <button onClick={this.searchByZipCode} id="signup" className="btn btn-primary">Search By Zip Code</button>
+                                
+                                {/* TODO(hannah): Make labels part of the clickable area. */}
+                                <div className="num-results">
+                                    <input
+                                        type="radio"
+                                        name="num-results"
+                                        value="top-5"
+                                        checked={!this.state.showAllResults}
+                                        onChange={this.numResultsChanged}
+                                    />
+                                    <label htmlFor="top-5">Closest 5 locations</label>
+                                    <br />
+                                    <input
+                                        type="radio"
+                                        name="num-results"
+                                        value="all"
+                                        checked={this.state.showAllResults}
+                                        onChange={this.numResultsChanged}
+                                    />
+                                    <label htmlFor="all">All locations</label>
+                                    <br />
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/styles/_app.scss
+++ b/styles/_app.scss
@@ -249,3 +249,11 @@ a {
 #geolocate {
   margin-bottom: 16px;
 }
+
+.num-results {
+  margin-top: 16px;
+
+  label {
+    margin-left: 4px;
+  }
+}

--- a/utils/distance-utils.js
+++ b/utils/distance-utils.js
@@ -24,9 +24,10 @@ function calculateDistance(record, pos_lat, pos_long) {
 }
 
 /**
- * Returns a list of the n closest locations to the given latitude and longitude.
+ * Returns a list of locations, sorted by increasing distance from the given
+ * latitude and longitude.
  */
-function getClosestLocations(locations, n, latitude, longitude) {
+function getClosestLocations(locations, latitude, longitude, showAllResults) {
     var locationsWithDistances = locations.map(location => ({
         location: location,
         distance: calculateDistance(location, latitude, longitude),
@@ -34,8 +35,12 @@ function getClosestLocations(locations, n, latitude, longitude) {
 
     locationsWithDistances.sort((a, b) => (a.distance - b.distance));
 
+    if (!showAllResults) {
+        // TODO(hannah): Make the number of results more configurable.
+        locationsWithDistances = locationsWithDistances.slice(0, 5);
+    }
+
     return locationsWithDistances
-        .slice(0, n)
         .map((locationWithDistance) => locationWithDistance.location);
 }
 


### PR DESCRIPTION
We received feedback that users missed being able to see all sites at once. (See https://vaccinatemaworkspace.slack.com/archives/C01L744H2DU/p1614047998045300.)

This PR adds a radio button to the search page that allows users to see all of the sites, sorted by location. It keeps "Closest 5 locations" as the default because (a) all the results could be overwhelming and (b) fetching the data will get slower as the number of vaccination sites increases. This gives us a temporary compromise!

<img width="679" alt="Screen Shot 2021-02-22 at 10 29 49 PM" src="https://user-images.githubusercontent.com/8495791/108799218-bd1af180-755d-11eb-956c-1fd11baab982.png">

### Test Plan:
* Select the "All locations" radio button and search by zip code. Scroll to see all results!
* Select "Closest 5 locations" and search by zip code again. See only 5 results.