### PR TITLE
Render URLs in other fields of search/map results

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import GoogleMapReact from 'google-map-react';
-import parseBookAppointmentString from './utilities/parseBookAppointmentString';
+import parseURLsInStrings from './utilities/parseURLsInStrings';
 
 // High volume, large venue sites
 const MASS_VACCINATION_SITES = [
@@ -33,10 +33,10 @@ const parseLocationData = data => {
             id: site.id,
             locationName: site.fields['Location Name'] ?? '',
             address: site.fields['Full Address'] ?? '',
-            populationsServed: site.fields['Serves'] ?? '',
-            vaccineAvailability: site.fields['Availability'] ?? '',
+            populationsServed: (site.fields['Serves'] && parseURLsInStrings(site.fields['Serves'])) ?? '',
+            vaccineAvailability: (site.fields['Availability'] && parseURLsInStrings(site.fields['Availability'])) ?? '',
             lastUpdated: (site.fields['Last Updated'] && parseDate(site.fields['Last Updated'])) ?? '',
-            bookAppointmentInformation: (site.fields['Book an appointment'] && parseBookAppointmentString(site.fields['Book an appointment'])) ?? '',
+            bookAppointmentInformation: (site.fields['Book an appointment'] && parseURLsInStrings(site.fields['Book an appointment'])) ?? '',
             latitude: site.fields['Latitude'] ?? 0,
             longitude: site.fields['Longitude'] ?? 0,
             sitePinShape: determineSitePinShape(

--- a/components/utilities/parseURLsInStrings.js
+++ b/components/utilities/parseURLsInStrings.js
@@ -21,7 +21,7 @@ const secondParser = (key, result) => (
  * 
  * @return array
  */
-const parseBookAppointmentString = text => {
+const parseURLsInStrings = text => {
     let config = [{
         regex: /(http|https):\/\/(\S+)\.([a-z]{2,}?)(.*?)( |,|$|\.)/gim,
         fn: firstParser
@@ -32,4 +32,4 @@ const parseBookAppointmentString = text => {
     return processString(config)(text);
 };
 
-export default parseBookAppointmentString;
+export default parseURLsInStrings;

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import Layout from '../components/Layout';
-import SearchResult from '../components/SearchResult';
-import parseBookAppointmentString from '../components/utilities/parseBookAppointmentString';
+import Site from '../components/Site';
+import parseURLsinStrings from '../components/utilities/parseURLsinStrings';
 
 class Search extends React.Component {
     constructor(props) {
@@ -72,19 +72,20 @@ class Search extends React.Component {
             });
     }
 
+<<<<<<< HEAD
     parseLocationData = (data) => {
         return data.map((site) => ({
             name: site.fields['Location Name'] ?? '',
             address: site.fields['Full Address'] ?? '',
-            siteDetails: site.fields['Serves'] ?? '',
-            availability: site.fields['Availability'] ?? 'None',
+            siteDetails: (site.fields['Serves'] && parseURLsInStrings(site.fields['Serves'])) ?? '',
+            availability: (site.fields['Availability'] && parseURLsInStrings(site.fields['Availability'])) ?? 'None',
             lastChecked:
                 (site.fields['Last Updated'] &&
                     this.parseDate(site.fields['Last Updated'])) ??
                 '',
             bookAppointmentInfo:
                 (site.fields['Book an appointment'] &&
-                    parseBookAppointmentString(
+                    parseURLsInStrings(
                         site.fields['Book an appointment']
                     )) ??
                 '',

--- a/pages/search.js
+++ b/pages/search.js
@@ -72,7 +72,6 @@ class Search extends React.Component {
             });
     }
 
-<<<<<<< HEAD
     parseLocationData = (data) => {
         return data.map((site) => ({
             name: site.fields['Location Name'] ?? '',

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Layout from '../components/Layout';
-import Site from '../components/Site';
+import SearchResult from '../components/SearchResult';
 import parseURLsInStrings from '../components/utilities/parseURLsInStrings';
 
 class Search extends React.Component {

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Layout from '../components/Layout';
 import Site from '../components/Site';
-import parseURLsinStrings from '../components/utilities/parseURLsinStrings';
+import parseURLsInStrings from '../components/utilities/parseURLsInStrings';
 
 class Search extends React.Component {
     constructor(props) {

--- a/pages/search.js
+++ b/pages/search.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Layout from '../components/Layout';
 import Site from '../components/Site';
-import parseURLsinStrings from '../components/utilities/parseURLsinStrings';
+import parseURLsInStrings from '../components/utilities/parseURLsInStrings';
 
 class Search extends React.Component {
     constructor(props) {

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Layout from '../components/Layout';
 import Site from '../components/Site';
-import parseBookAppointmentString from '../components/utilities/parseBookAppointmentString';
+import parseURLsinStrings from '../components/utilities/parseURLsinStrings';
 
 class Search extends React.Component {
     constructor(props) {
@@ -77,10 +77,10 @@ class Search extends React.Component {
             {
                 locationName: site.fields['Location Name'] ?? '',
                 address: site.fields['Full Address'] ?? '',
-                populationsServed: site.fields['Serves'] ?? '',
-                vaccineAvailability: site.fields['Availability'] ?? '',
+                populationsServed: (site.fields['Serves'] && parseURLsInStrings(site.fields['Serves'])) ?? '',
+                vaccineAvailability: (site.fields['Availability'] && parseURLsInStrings(site.fields['Availability'])) ?? '',
                 lastUpdated: (site.fields['Last Updated'] && this.parseDate(site.fields['Last Updated'])) ?? '',
-                bookAppointmentInformation: (site.fields['Book an appointment'] && parseBookAppointmentString(site.fields['Book an appointment'])) ?? ''
+                bookAppointmentInformation: (site.fields['Book an appointment'] && parseURLsInStrings(site.fields['Book an appointment'])) ?? ''
             }
         ));
     }

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Layout from '../components/Layout';
 import Site from '../components/Site';
-import parseBookAppointmentString from '../components/utilities/parseBookAppointmentString';
+import parseURLsinStrings from '../components/utilities/parseURLsinStrings';
 
 class Search extends React.Component {
     constructor(props) {
@@ -76,10 +76,10 @@ class Search extends React.Component {
             {
                 locationName: site.fields['Location Name'] ?? '',
                 address: site.fields['Full Address'] ?? '',
-                populationsServed: site.fields['Serves'] ?? '',
-                vaccineAvailability: site.fields['Availability'] ?? '',
+                populationsServed: (site.fields['Serves'] && parseURLsInStrings(site.fields['Serves'])) ?? '',
+                vaccineAvailability: (site.fields['Availability'] && parseURLsInStrings(site.fields['Availability'])) ?? '',
                 lastUpdated: (site.fields['Last Updated'] && this.parseDate(site.fields['Last Updated'])) ?? '',
-                bookAppointmentInformation: (site.fields['Book an appointment'] && parseBookAppointmentString(site.fields['Book an appointment'])) ?? ''
+                bookAppointmentInformation: (site.fields['Book an appointment'] && parseURLsInStrings(site.fields['Book an appointment'])) ?? ''
             }
         ));
     }


### PR DESCRIPTION
This changes renders clickable links in the "serves" and "availability" fields of search/map results in addition to just the "book an appointment field". Bug fix for https://trello.com/c/0IyAcrcF/84-ensure-gov-links-are-clickable-in-the-map-popovers