### PR TITLE
Make Harlan-directed changes to search result cards.

### DIFF
--- a/components/SearchResult.js
+++ b/components/SearchResult.js
@@ -82,7 +82,7 @@ SearchResult.propTypes = {
     name: PropTypes.string.isRequired,
     address: PropTypes.string.isRequired,
     siteDetails: PropTypes.string.isRequired,
-    availability: PropTypes.arrayOf(PropTypes.string).isRequired,
+    availability: PropTypes.array.isRequired,
     lastChecked: PropTypes.string.isRequired,
     bookAppointmentInfo: PropTypes.array.isRequired,
 };

--- a/components/SearchResult.js
+++ b/components/SearchResult.js
@@ -26,7 +26,7 @@ const SearchResult = (props) => {
                     <div className="site-name">
                         <h3>{props.name}</h3>
                         <p>
-                            {props.address}
+                            <span className="address">{props.address}</span>
                             <a
                                 href={googleMapsLink}
                                 target="_blank"
@@ -82,7 +82,7 @@ SearchResult.propTypes = {
     name: PropTypes.string.isRequired,
     address: PropTypes.string.isRequired,
     siteDetails: PropTypes.string.isRequired,
-    availability: PropTypes.string.isRequired,
+    availability: PropTypes.arrayOf(PropTypes.string).isRequired,
     lastChecked: PropTypes.string.isRequired,
     bookAppointmentInfo: PropTypes.array.isRequired,
 };

--- a/pages/search.js
+++ b/pages/search.js
@@ -77,7 +77,10 @@ class Search extends React.Component {
             name: site.fields['Location Name'] ?? '',
             address: site.fields['Full Address'] ?? '',
             siteDetails: site.fields['Serves'] ?? '',
-            availability: site.fields['Availability'] ?? 'None',
+            availability:
+                (site.fields['Availability'] &&
+                    parseBookAppointmentString(site.fields['Availability'])) ??
+                'None',
             lastChecked:
                 (site.fields['Last Updated'] &&
                     this.parseDate(site.fields['Last Updated'])) ??
@@ -117,7 +120,7 @@ class Search extends React.Component {
 
             return (
                 <div>
-                    <h2>Results:</h2>
+                    <h2>Results</h2>
                     <ul id="sites" className="list-group" ref={this.siteDataResultsRef}>
                         {sites}
                     </ul>

--- a/styles/_searchResults.scss
+++ b/styles/_searchResults.scss
@@ -13,6 +13,7 @@
 
     p {
         font-size: 16px;
+        overflow-wrap: break-word;
     }
 
     .header-available {
@@ -31,28 +32,38 @@
             flex-direction: column;
         }
 
-        h4 {
-            font-size: 21px;
-            font-weight: 700;
+        h3 {
+            align-items: flex-end;
+            display: flex;
+            min-height: 50%;
         }
 
-        p {
-            font-size: 14px;
+        h4 {
+            align-items: flex-end;
+            display: flex;
+            font-size: 21px;
+            font-weight: 700;
+            min-height: 50%;
         }
 
         a {
             color: black;
             font-weight: 800;
-            margin-left: 8px;
             text-decoration: none;
+            white-space: nowrap;
+        }
+
+        .address {
+            margin-right: 8px;
         }
 
         @media screen and (min-width: 768px) {
             .site-name {
-                width: 66%;
+                width: 60%;
+                margin-right: 6%;
             }
             .availability {
-                width: 33%;
+                width: 30%;
             }
         }
     }
@@ -75,7 +86,7 @@
 
     .contents {
         flex: 1;
-        width: 100%;
+        width: calc(100% - 8px);
     }
 
     .result-body {
@@ -89,7 +100,8 @@
 
         @media screen and (min-width: 768px) {
             div {
-                width: 33%;
+                width: 30%;
+                margin-right: 3%;
             }
         }
     }


### PR DESCRIPTION
At tonight's meeting, Harlan asked for the following fixes (all of which are addressed by this PR):
- Line up the baselines of the site name and "Appointments may be available" / "No appointments available"
- Increase the gutters to 3% width
- Prevent links from spilling into other sections
- Make links in availability section clickable
- Keep "Get directions" together
- Don't let the content cover the side bar
- Change the address text to be 16px
- Remove the colon from after "Results"

Before:
![Screen Shot 2021-02-23 at 9 52 05 PM](https://user-images.githubusercontent.com/8495791/108940534-873f4100-7621-11eb-8690-b6fc08cc9789.png)

After:
![Screen Shot 2021-02-23 at 9 52 36 PM](https://user-images.githubusercontent.com/8495791/108940531-84dce700-7621-11eb-91bf-1882a8daba8e.png)
