### PR TITLE
Remove appWithTranslation until we're using the i18n framework.

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,7 +3,6 @@ import App from 'next/app';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../styles/index.scss';
-import {appWithTranslation} from '../i18n';
 
 class VaccinateMAApp extends App {
     render() {
@@ -15,4 +14,6 @@ class VaccinateMAApp extends App {
     }
 }
 
-export default appWithTranslation(VaccinateMAApp);
+// TODO(hannah): Restore appWithTranslation once we actually have translations.
+// export default appWithTranslation(VaccinateMAApp);
+export default VaccinateMAApp;


### PR DESCRIPTION
Since we're not actually using NextI18Next, it complains a lot in dev mode. Commenting it out until we're actually using it correctly!

### Test Plan:
* Run `node app.js`
* See none of these complaints:
```
You have not declared a namespacesRequired array on your page-level component: Home. This will cause all namespaces to be sent down to the client, possibly negatively impacting the performance of your app. For more info, see: https://github.com/isaachinman/next-i18next#4-declaring-namespace-dependencies
```