### PR TITLE
Extend button to handle both actions and links.

### DIFF
--- a/components/subcomponents/Button.js
+++ b/components/subcomponents/Button.js
@@ -1,28 +1,62 @@
 import React from 'react';
+import Link from 'next/link';
 import PropTypes from 'prop-types';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faSearch, faLocationArrow} from '@fortawesome/free-solid-svg-icons';
 
-const Button = (props) => (
-    <button
-        className={`button-custom button-custom-${props.color}`}
-        onClick={props.onClick}
-    >
-        {props.icon && props.icon == 'search' && (
-            <FontAwesomeIcon icon={faSearch} />
-        )}
-        {props.icon && props.icon == 'location' && (
-            <FontAwesomeIcon icon={faLocationArrow} />
-        )}
-        {props.title}
-    </button>
+/**
+ * A button that triggers some action on click.
+ */
+export const ActionButton = (props) => (
+    <Button {...props} />
 );
 
-export default Button;
+/**
+ * A button that redirects to another page or website.
+ */
+export const LinkButton = (props) => (
+    <Link href={props.href} passHref>
+        <Button {...props} />
+    </Link>
+);
 
-Button.propTypes = {
+const Button = React.forwardRef((props, ref) => (
+    <div className={`button-custom button-custom-${props.color}`}>
+        <a
+            href={props.href}
+            onClick={props.onClick}
+            ref={ref}
+        >
+            {props.icon && props.icon == 'search' && (
+                <FontAwesomeIcon icon={faSearch} />
+            )}
+            {props.icon && props.icon == 'location' && (
+                <FontAwesomeIcon icon={faLocationArrow} />
+            )}
+            {props.title}
+        </a>
+    </div>
+));
+
+const sharedProps = {
     title: PropTypes.string.isRequired,
     icon: PropTypes.oneOf(['search', 'location']),
     color: PropTypes.oneOf(['gray', 'blue', 'green']).isRequired,
-    onClick: PropTypes.func.isRequired,
+};
+
+ActionButton.propTypes = {
+    ...sharedProps,
+    onClick: PropTypes.func,
+};
+
+LinkButton.propTypes = {
+    ...sharedProps,
+    href: PropTypes.string,
+};
+
+Button.displayName = 'Button';
+Button.propTypes = {
+    ...sharedProps,
+    onClick: PropTypes.func,
+    href: PropTypes.string,
 };

--- a/styles/_button.scss
+++ b/styles/_button.scss
@@ -2,6 +2,7 @@
     border-radius: 4px;
     border: none;
     color: $white;
+    display: inline-block;
     font-size: 21px;
     font-weight: 800;
     padding: 16px;
@@ -9,6 +10,11 @@
     // Add a shadow that animates out on hover / click.
     box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.15);
     transition: box-shadow 0.3s ease-out;
+
+    a {
+        color: $white;
+        text-decoration: none;
+    }
 
     svg {
         margin-right: 12px;


### PR DESCRIPTION
The original button component I introduced was only able to handle `onClick` actions. We may need buttons that can handle `href`s instead (if we implement the by-date buttons on the modal, for example). We don't need them yet though so I'm going to open + close this PR for future reference.