### PR TITLE
Correctly show red star for mass vaccination site

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -51,10 +51,10 @@ const parseLocationData = data => {
 const determineSitePinShape = (availability, serves, locationName) => {
     if (!availability || availability?.trim() === 'None') {
         return 'dot';
-    } else if (doesSiteServeAllEligiblePeopleStatewide(serves)) {
-        return 'star star-green';
     } else if (isSiteAMassVaccinationSite(locationName)) {
         return 'star star-red';
+    } else if (doesSiteServeAllEligiblePeopleStatewide(serves)) {
+        return 'star star-green';
     } else {
         return 'star star-blue';
     }


### PR DESCRIPTION
Currently, we check whether a location serves everyone statewide before checking if it is a mass vaccination site. The conditions are not mutually exclusive, so we should check if it's a mass vax site first and only otherwise choose between a statewide-eligible site and a local one.