### PR TITLE
Fix check for availability in search results.

### DIFF
--- a/components/SearchResult.js
+++ b/components/SearchResult.js
@@ -5,7 +5,9 @@ import {faMapMarkerAlt} from '@fortawesome/free-solid-svg-icons';
 
 const SearchResult = (props) => {
     const hasAvailability =
-        props.availability !== '' && props.availability !== 'None';
+        props.availability.length > 0 &&
+        props.availability[0] &&
+        props.availability[0][0] !== 'None';
     const googleMapsLink = 'https://maps.google.com/?q=' + props.address;
 
     return (

--- a/pages/search.js
+++ b/pages/search.js
@@ -83,7 +83,7 @@ class Search extends React.Component {
             availability:
                 (site.fields['Availability'] &&
                     parseURLsInStrings(site.fields['Availability'])) ??
-                'None',
+                [],
             lastChecked:
                 (site.fields['Last Updated'] &&
                     this.parseDate(site.fields['Last Updated'])) ??
@@ -91,7 +91,7 @@ class Search extends React.Component {
             bookAppointmentInfo:
                 (site.fields['Book an appointment'] &&
                     parseURLsInStrings(site.fields['Book an appointment'])) ??
-                '',
+                [],
         }));
     };
     parseDate = dateString => (


### PR DESCRIPTION
I noticed that locations without availability were showing up as green cards in the search results.

It looks like `parseURLsInStrings` actually returns an array of arrays (of strings) or objects (which are the links). So the check for `'None'` was always failing.

Our data structure is quite fragile -- lots of string parsing -- so we should clean that up as we go.

### Test Plan:
* Search for all locations.
* See search results with no availability ("None") show up as gray cards.