### PR TITLE
Change 'Book now' field in map to 'Make an appointment'

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -112,7 +112,7 @@ const Popup = ({data, setPopupData}) => (
                 <p><b>Address</b> {data.address}</p>
                 <p><b>Availability</b> {data.vaccineAvailability || 'None'}</p>
                 <p>(Availability last updated {data.lastUpdated})</p>
-                <p><b>Book now</b> {data.bookAppointmentInformation}</p>
+                <p><b>Make an appointment</b> {data.bookAppointmentInformation}</p>
                 <button onClick={() => setPopupData({})}>Close</button>
             </div>
         </div>


### PR DESCRIPTION
Matching copy to that of the search results boxes. This is useful because sometimes we say the availability is "see 'book now' for waitlist info" and that doesn't make sense if there is no 'book now' field in search results