### PR TITLE
Factor out data fetching from map component.

### DIFF
--- a/components/MapWithData.js
+++ b/components/MapWithData.js
@@ -1,0 +1,22 @@
+import React, {useEffect, useState} from 'react';
+
+import Map from './subcomponents/Map';
+
+const MapWithData = () => {
+    const [rawSiteData, setRawSiteData] = useState([]);
+
+    useEffect(
+        () => {
+            fetch('/initmap')
+                .then((response) => response.json())
+                .then((rawSiteData) => setRawSiteData(rawSiteData))
+                .catch((err) => console.error(err));
+        },
+        // Empty array as 2nd param so function runs only on initial page load.
+        []
+    );
+
+    return <Map rawSiteData={rawSiteData} />;
+};
+
+export default MapWithData;

--- a/components/subcomponents/Map.js
+++ b/components/subcomponents/Map.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import GoogleMapReact from 'google-map-react';
-import parseURLsInStrings from './utilities/parseURLsInStrings';
+import parseURLsInStrings from '../utilities/parseURLsInStrings';
 
 // High volume, large venue sites
 const MASS_VACCINATION_SITES = [
@@ -133,7 +133,7 @@ Popup.propTypes = {
     setPopupData: PropTypes.func,
 };
 
-const Map = ({height = '400px', width = '100%'}) => {
+const Map = ({height = '400px', width = '100%', rawSiteData}) => {
     const [siteData, setSiteData] = useState([]);
     const [popupData, setPopupData] = useState({});
 
@@ -148,12 +148,10 @@ const Map = ({height = '400px', width = '100%'}) => {
         return key === site.id;
     });
 
+    // Update the site data whenever the rawSiteData props change.
     useEffect(() => {
-        fetch('/initmap')
-            .then(response => response.json())
-            .then(siteData => parseLocationData(siteData))
-            .then(siteData => setSiteData(siteData));
-    }, []); // empty array as 2nd param so that function runs only on initial page load
+        setSiteData(parseLocationData(rawSiteData));
+    }, [rawSiteData]);
 
     return (
     // Container element must have height and width for map to display. See https://developers.google.com/maps/documentation/javascript/overview#Map_DOM_Elements
@@ -189,6 +187,8 @@ const Map = ({height = '400px', width = '100%'}) => {
 Map.propTypes = {
     height: PropTypes.string,
     width: PropTypes.string,
+    // The raw site data should be JSON. Improve the type checking here!
+    rawSiteData: PropTypes.any.isRequired,
 };
 
 export default Map;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Layout from '../components/Layout';
-import Map from '../components/Map';
+import MapWithData from '../components/MapWithData';
 
 const Home = () => (
     <Layout pageTitle="Home">
@@ -14,7 +14,7 @@ const Home = () => (
                 </div>
         
             </div>
-            <Map />
+            <MapWithData />
             <br />
             <p> <b> Red star: </b> Mass Vaccination Sites (high volume, large venue sites) </p>
             <p> <b> Green star: </b> General Vaccination Sites (healthcare locations) </p>


### PR DESCRIPTION
When we combine the map and search views, we'll want to share one data source. (In other words, the map pins and search result cards should show the same vaccination sites.)

This PR is a step towards that goal. It introduces a wrapper component, `MapWithData` that is responsible for fetching the data.

### Test Plan:
Ensure the pins on the map display as usual and without console errors.