### PR TITLE
Add available site count.

### DIFF
--- a/components/MapAndListView.js
+++ b/components/MapAndListView.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 
 import AvailabilityBanner from './subcomponents/AvailabilityBanner';
@@ -8,15 +8,10 @@ import ListView from './subcomponents/ListView';
 
 const MapAndListView = (props) => {
     const [showMap, setShowMap] = useState(true);
-    const [numAvailable, setNumAvailable] = useState(0);
 
-    // Update numAvailable whenever props.rawSiteData changes.
-    useEffect(() => {
-        setNumAvailable(
-            props.rawSiteData.filter((site) => site.availability.length > 0)
-                .length
-        );
-    }, [props.rawSiteData]);
+    const numAvailable = props.rawSiteData.filter(
+        (site) => site.availability.length > 0
+    ).length;
 
     return (
         <div className="map-and-list">

--- a/components/MapAndListView.js
+++ b/components/MapAndListView.js
@@ -1,15 +1,29 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 
+import AvailabilityBanner from './subcomponents/AvailabilityBanner';
 import Button from './subcomponents/Button';
 import Map from './subcomponents/Map';
 import ListView from './subcomponents/ListView';
 
 const MapAndListView = (props) => {
     const [showMap, setShowMap] = useState(true);
+    const [numAvailable, setNumAvailable] = useState(0);
+
+    // Update numAvailable whenever props.rawSiteData changes.
+    useEffect(() => {
+        setNumAvailable(
+            props.rawSiteData.filter((site) => site.availability.length > 0)
+                .length
+        );
+    }, [props.rawSiteData]);
 
     return (
         <div className="map-and-list">
+            <AvailabilityBanner
+                numSites={numAvailable}
+                hasAvailability={true}
+            />
             <div className="button-container">
                 <Button
                     title="Map View"

--- a/components/subcomponents/AvailabilityBanner.js
+++ b/components/subcomponents/AvailabilityBanner.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faCheckCircle, faTimesCircle} from '@fortawesome/free-solid-svg-icons';
+
+const AvailabilityBanner = (props) => {
+    // TODO(hannah): Before we can translate this, we'll need a good
+    // interpolation solution.
+    const text = props.hasAvailability ? (
+        props.numSites == 1 ? (
+            <p>
+                <b>1</b> site has reported available appointments.
+            </p>
+        ) : (
+            <p>
+                <b>{props.numSites}</b> sites have reported available
+                appointments.
+            </p>
+        )
+    ) : props.numSites == 1 ? (
+        <p>
+            There is <b>1</b> site that reports no available appointments.
+        </p>
+    ) : (
+        <p>
+            There are <b>{props.numSites}</b> sites that report no available
+            appointments.
+        </p>
+    );
+
+    return (
+        <span className="availability-banner">
+            <FontAwesomeIcon
+                icon={props.hasAvailability ? faCheckCircle : faTimesCircle}
+            />
+            {text}
+        </span>
+    );
+};
+
+export default AvailabilityBanner;
+
+AvailabilityBanner.propTypes = {
+    numSites: PropTypes.number.isRequired,
+    hasAvailability: PropTypes.bool.isRequired,
+};

--- a/styles/_app.scss
+++ b/styles/_app.scss
@@ -249,3 +249,16 @@ a {
 #geolocate {
   margin-bottom: 16px;
 }
+
+.availability-banner {
+  display: flex;
+  flex-direction: row;
+  font-size: 27px;
+  margin-bottom: 16px;
+  margin-top: 32px;
+
+  p {
+    margin-bottom: 0px;
+    margin-left: 16px;
+  }
+}


### PR DESCRIPTION
This PR adds the "x sites have reported available appointments" banner. Given that we need to (1) change the string based on whether the count is singular or plural and (2) bold the number of appointments, we'll need a good interpolation solution before we can translate this component. (This PR assumes English for now.)

Designs: https://www.figma.com/file/lQPDvm8Kuwqeig5Dusbq8j/VaccinateMA_UI?node-id=338%3A489

<img width="1131" alt="Screen Shot 2021-03-06 at 11 58 31 AM" src="https://user-images.githubusercontent.com/8495791/110214609-62de3280-7e73-11eb-8580-0a5992bd55af.png">
