### PR TITLE
Express-rate-limit Integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,8 +88,8 @@ if (cluster.isMaster) {
     app.prepare().then(() => {
         var server = express();
 
-        // Set rate limiting for all features as a first cut.
-        // This will most probably need some refinement for specific endpoints and multi-server scaling.
+        // Set rate limiting for all features.
+        server.set('trust proxy', 1);
         const rateLimit = require('express-rate-limit');
         const limiter = rateLimit({  // The rate limit is 100 requests per 15 minutes.  This will easily clear our heartbeat synths for now.
             windowMs: 15 * 60 * 1000,

--- a/app.js
+++ b/app.js
@@ -88,6 +88,15 @@ if (cluster.isMaster) {
     app.prepare().then(() => {
         var server = express();
 
+        // Set rate limiting for all features as a first cut.
+        // This will most probably need some refinement for specific endpoints and multi-server scaling.
+        const rateLimit = require('express-rate-limit');
+        const limiter = rateLimit({  // The rate limit is 100 requests per 15 minutes.  This will easily clear our heartbeat synths for now.
+            windowMs: 15 * 60 * 1000,
+            max: 100
+        });
+        server.use(limiter);
+
         server.use(bodyParser.urlencoded({extended:false}));
         server.use(bodyParser.json());
 

--- a/bin/test-rate-limit.sh
+++ b/bin/test-rate-limit.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# A quick test harness to feel out the express-rate-limit features.
+# Hits the URL you specify as a command-line argument 150 times in quick succession.
+#
+# Arguments:
+# - the URL to hit
+
+for i in `seq 1 150`; do
+    echo $i
+    curl -s -o /dev/null -w "%{http_code}" $1
+    echo
+done

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^8.2.0",
     "ejs": "latest",
     "express": "latest",
+    "express-rate-limit": "^5.2.6",
     "express-validator": "^6.9.2",
     "google-geocoder": "^0.2.1",
     "google-map-react": "^2.1.9",


### PR DESCRIPTION
Since this is my first check-in, I set a pretty low bar for integrating express-rate-limit.  Specifically, I'm limiting every single resource to 100 requests per 15 minutes.  At that rate, I have little concern of creating false alerts because we are limiting our synthetics.

That being said, I will need to update this (nearly immediately) to handle multi-server scaling sets.