### PR TITLE
Make "low priority" footer fixes.

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -50,12 +50,14 @@ const Footer = () => {
                     <LinkedinShareButton url="http://vaccinatema.com/">
                         <FontAwesomeIcon icon={faLinkedin} />
                     </LinkedinShareButton>
+                    {/* Ensure margins are consistent with other footer-boxes. */}
+                    <p />
                 </div>
             </div>
             <div className="footer-box">
                 <h2 className="footer-heading">Get involved</h2>
                 <p>Email us at{' '}<EmailLink/>{' '}if you&apos;d like to help out.</p>
-                <h2>Feedback</h2>
+                <h2 className="footer-heading">Feedback</h2>
                 <p>
           Like the site? Found a bug? Have a feature idea?
           Get a vaccine from info you found here?{' '}
@@ -68,7 +70,7 @@ const Footer = () => {
                     </a>
                 </p>
             </div>
-            <div className="footer-box">
+            <div className="footer-box disclaimer">
                 <h2 className="footer-heading">Disclaimer</h2>
                 <p>
           This site was put together by volunteers using our best efforts to assemble readily available data from

--- a/styles/_app.scss
+++ b/styles/_app.scss
@@ -101,8 +101,9 @@ a {
   background: #D0DDE9;
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-around;
+  justify-content: space-between;
   padding: 15px 15px 0 15px;
+  overflow: hidden;
   h2 {
     font-size: 21px;
     line-height: 26px;
@@ -110,9 +111,10 @@ a {
   }
   .footer-box {
     display: block;
-    width: 30%;
-    min-width: 300px;
-    padding: 0 5px 15px 5px;
+    @media screen and (min-width: 768px) {
+      width: 30%;
+      min-width: 300px;
+    }
     p {
       font-size: 16px;
     }
@@ -141,6 +143,13 @@ a {
         color: black;
         margin-right: 10px;
       }
+    }
+  }
+  .disclaimer {
+    // 1000px is the width at which the disclaimer goes on to its own line
+    // (each of the 3 columns has a width of 30% and a min-width of 300px).
+    @media screen and (max-width: 1000px) {
+      flex: 1;
     }
   }
 }


### PR DESCRIPTION
Addresses Harlan's feedback:
> Medium size screen: Disclaimer should be full width
> Small screen: uneven padding between between text groups

Trello card: https://trello.com/c/Wn4yiMdp/90-footer-style-update-low-priority

Also fixes the issue of content overflowing horizontally on mobile.

Large
<img width="941" alt="Screen Shot 2021-03-08 at 9 42 25 PM" src="https://user-images.githubusercontent.com/8495791/110410845-8e217700-8057-11eb-893b-52af02b38321.png">

Medium
<img width="576" alt="Screen Shot 2021-03-08 at 9 41 49 PM" src="https://user-images.githubusercontent.com/8495791/110410879-9a0d3900-8057-11eb-914b-00afbaa99392.png">

Small
<img width="373" alt="Screen Shot 2021-03-08 at 9 40 51 PM" src="https://user-images.githubusercontent.com/8495791/110410894-9f6a8380-8057-11eb-84fa-f8ab8fdf48be.png">
