### PR TITLE
Redirect from `/search` to home.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,8 @@ module.exports = {
     distDir: 'static/_next',
     async redirects() {
         return [
+            // The original website had a separate search page; now search
+            // functionality lives on the home page.
             {
                 source: '/search',
                 destination: '/',

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,12 @@
 module.exports = {
     distDir: 'static/_next',
+    async redirects() {
+        return [
+            {
+                source: '/search',
+                destination: '/',
+                permanent: true,
+            },
+        ];
+    },
 };


### PR DESCRIPTION
@snyderc pointed out that we should redirect from `/search` to `/` in case anyone bookmarked `/search`.

Luckily Next.js makes redirects really easy! (Documentation [here](https://nextjs.org/docs/api-reference/next.config.js/redirects).)

### Test Plan:
Navigate to `/search`. Ensure you're redirected to `/`!