### PR TITLE
Move the availability banner below the map/list toggle.

### DIFF
--- a/components/MapAndListView.js
+++ b/components/MapAndListView.js
@@ -15,10 +15,6 @@ const MapAndListView = (props) => {
 
     return (
         <div className="map-and-list">
-            <AvailabilityBanner
-                numSites={numAvailable}
-                hasAvailability={true}
-            />
             <div className="button-container">
                 <Button
                     title="Map View"
@@ -35,6 +31,10 @@ const MapAndListView = (props) => {
                     borderRadius={'0px 4px 4px 0px'}
                 />
             </div>
+            <AvailabilityBanner
+                numSites={numAvailable}
+                hasAvailability={true}
+            />
             <div className="map-and-list-contents">
                 {showMap ? (
                     <div>


### PR DESCRIPTION
Harlan decided that the availability banner should be below the map/list toggle. It's too easy to miss as is.

<img width="1140" alt="Screen Shot 2021-03-10 at 9 16 47 AM" src="https://user-images.githubusercontent.com/8495791/110642955-8d84ff80-8181-11eb-9210-5213bfd20f74.png">
