### PR TITLE
Set coordinates and zoom on search.

### DIFF
--- a/app.js
+++ b/app.js
@@ -109,13 +109,13 @@ if (cluster.isMaster) {
             }
 
             const {lat, lng} = await distanceUtils.getLatLngFromRequest(req);
-            const closest = distanceUtils.getClosestLocations(
+            const siteData = distanceUtils.getClosestLocations(
                 locations,
                 lat,
                 lng,
                 req.body.maxMiles,
             );
-            res.send(closest);
+            res.send({siteData, lat, lng});
         });
 
         // THE API ROUTES WE HAVE DEFINED NEED TO BE ADDED HERE:

--- a/components/MapAndListView.js
+++ b/components/MapAndListView.js
@@ -13,6 +13,10 @@ const MapAndListView = (props) => {
         (site) => site.availability.length > 0
     ).length;
 
+    const mapProps = props.mapCoordinates
+        ? {coordinates: props.mapCoordinates, zoom: 4}
+        : {};
+
     return (
         <div className="map-and-list">
             <AvailabilityBanner
@@ -38,7 +42,7 @@ const MapAndListView = (props) => {
             <div className="map-and-list-contents">
                 {showMap ? (
                     <div>
-                        <Map rawSiteData={props.rawSiteData} />
+                        <Map {...mapProps} rawSiteData={props.rawSiteData} />
                         <MapKey />
                     </div>
                 ) : (
@@ -75,4 +79,8 @@ export default MapAndListView;
 MapAndListView.propTypes = {
     // The raw site data should be JSON. Improve the type checking here!
     rawSiteData: PropTypes.any.isRequired,
+    mapCoordinates: PropTypes.shape({
+        lat: PropTypes.number,
+        lng: PropTypes.number,
+    }),
 };

--- a/components/subcomponents/Map.js
+++ b/components/subcomponents/Map.js
@@ -130,16 +130,16 @@ Popup.propTypes = {
     setPopupData: PropTypes.func,
 };
 
-const Map = ({height = '400px', width = '100%', rawSiteData}) => {
+const Map = ({
+    height = '400px',
+    width = '100%',
+    rawSiteData,
+    // The default coordinates are those of Boston.
+    coordinates = {lat: 42.360081, lng: -71.058884},
+    zoom = 8,
+}) => {
     const [siteData, setSiteData] = useState([]);
     const [popupData, setPopupData] = useState({});
-
-    const bostonCoordinates = {
-        lat: 42.360081,
-        lng: -71.058884
-    };
-
-    const defaultMassachusettsZoom = 8;
 
     const getSiteDataByKey = key => siteData.find(site => {
         return key === site.id;
@@ -155,8 +155,8 @@ const Map = ({height = '400px', width = '100%', rawSiteData}) => {
         <div style={{ height, width }}>
             <GoogleMapReact
                 bootstrapURLKeys={{ key: 'AIzaSyDLApAjP27_nCB5BbfICaJ0sJ1AmmuMkD0' }}
-                defaultCenter={bostonCoordinates}
-                defaultZoom={defaultMassachusettsZoom}
+                center={coordinates}
+                zoom={zoom}
                 draggableCursor="crosshair"
             >
                 {siteData && siteData.map((site) => (
@@ -186,6 +186,11 @@ Map.propTypes = {
     width: PropTypes.string,
     // The raw site data should be JSON. Improve the type checking here!
     rawSiteData: PropTypes.any.isRequired,
+    coordinates: PropTypes.shape({
+        lat: PropTypes.number,
+        lng: PropTypes.number,
+    }),
+    zoom: PropTypes.number,
 };
 
 export default Map;

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,7 @@ import SearchBar from '../components/SearchBar';
 
 const Home = () => {
     const [rawSiteData, setRawSiteData] = useState([]);
+    const [mapCoordinates, setMapCoordinates] = useState(null);
 
     useEffect(
         () => {
@@ -37,7 +38,11 @@ const Home = () => {
             body: JSON.stringify({...args}),
         })
             .then((response) => response.json())
-            .then((siteData) => setRawSiteData(siteData))
+            .then((response) => {
+                const {lat, lng, siteData} = response;
+                setRawSiteData(siteData);
+                setMapCoordinates({lat, lng});
+            })
             .catch((error) => {
                 // TODO(hannah): Add better error handling.
                 console.log(error);
@@ -48,7 +53,10 @@ const Home = () => {
         <Layout pageTitle="Home">
             <div>
                 <SearchBar onSearch={getLocationData} />
-                <MapAndListView rawSiteData={rawSiteData} />
+                <MapAndListView
+                    mapCoordinates={mapCoordinates}
+                    rawSiteData={rawSiteData}
+                />
             </div>
         </Layout>
     );


### PR DESCRIPTION
Per design review with Harlan: when a user performs a search, we want to center the map on the search location and zoom in.

Unfortunately, the Google Map component still doesn't work locally so I'm not 100% sure this will work... I'll land to `staging.` and iterate from there!