### PR TITLE
Add Reggie Lewis as mass vax site and remove Lowell General 

### DIFF
--- a/components/subcomponents/Map.js
+++ b/components/subcomponents/Map.js
@@ -12,8 +12,8 @@ const MASS_VACCINATION_SITES = [
     'Danvers: Doubletree Hotel',
     'Springfield: Eastfield Mall',
     'Dartmouth: Former Circuit City', 
-    'Lowell: Lowell General Hospital at Cross River Center',
-    'Natick: Natick Mall'
+    'Natick: Natick Mall',
+    'Boston: Reggie Lewis Center (Roxbury Community College)'
 ];
 
 const ELIGIBLE_PEOPLE_STATEWIDE_TEXT = [


### PR DESCRIPTION
Apparently Lowell is not an official mass vax site. Can't add a screenshot because my map throws an error when running locally (always...I think it's an API key error/IP address thing)