### PR TITLE
Zoom back out on empty search.

### DIFF
--- a/components/subcomponents/Map.js
+++ b/components/subcomponents/Map.js
@@ -155,7 +155,7 @@ const Map = ({
     // Update the center and zoom whenever the given coordinates change.
     useEffect(() => {
         setCenter(coordinates);
-        setZoom(12);
+        setZoom(coordinates == BOSTON_COORDINATES ? 8 : 12);
     }, [coordinates]);
 
     const handleChange = ({center, zoom}) => {


### PR DESCRIPTION
If a user clears their search, we should reset the center to the Boston coordinates (which we already do) and reset the zoom to 8 (which this PR does).

Since we still don't have a dev API key for Google Maps, I'll have to land this on `develop` and test on staging.vaccinatema.com.