### PR TITLE
Add Hynes Convention Center to the list of mass vax sites

### DIFF
--- a/components/subcomponents/Map.js
+++ b/components/subcomponents/Map.js
@@ -13,7 +13,8 @@ const MASS_VACCINATION_SITES = [
     'Springfield: Eastfield Mall',
     'Dartmouth: Former Circuit City', 
     'Natick: Natick Mall',
-    'Boston: Reggie Lewis Center (Roxbury Community College)'
+    'Boston: Reggie Lewis Center (Roxbury Community College)',
+    'Boston: Hynes Convention Center'
 ];
 
 const ELIGIBLE_PEOPLE_STATEWIDE_TEXT = [


### PR DESCRIPTION
Just a quick change to make the Hynes star red instead of green. No Google Maps API key, so I don't have a screenshot.