### PR TITLE
Maintain map state when toggling between "map" and "list" views.

### DIFF
--- a/components/MapAndListView.js
+++ b/components/MapAndListView.js
@@ -40,14 +40,14 @@ const MapAndListView = (props) => {
                 hasAvailability={true}
             />
             <div className="map-and-list-contents">
-                {showMap ? (
-                    <div>
-                        <Map {...mapProps} rawSiteData={props.rawSiteData} />
-                        <MapKey />
-                    </div>
-                ) : (
-                    <ListView rawSiteData={props.rawSiteData} />
-                )}
+                {/* Use display: 'none' to avoid rerendering the map and
+                losing state (map zoom and center) each time the user toggles
+                between the map and list views. */}
+                <div style={showMap ? {} : {display: 'none'}}>
+                    <Map {...mapProps} rawSiteData={props.rawSiteData} />
+                    <MapKey />
+                </div>
+                {!showMap && <ListView rawSiteData={props.rawSiteData} />}
             </div>
         </div>
     );


### PR DESCRIPTION
Currently, if you move or zoom the map, then go to the "list" view, the map will be "reset" to the default view. This is because we remove and re-add the map component to the component tree. This change uses CSS to hide the map view instead so we can render it once and maintain state, even when toggling between the two views.

![Mar-28-2021 14-15-52](https://user-images.githubusercontent.com/8495791/112764003-c3751100-8fd4-11eb-84fd-fcf3c67ac5ad.gif)
