### PR TITLE
Remove Fenway from list of mass vaccination sites.

### DIFF
--- a/components/subcomponents/Map.js
+++ b/components/subcomponents/Map.js
@@ -8,7 +8,6 @@ import {dateToString} from '../utilities/date-utils';
 // High volume, large venue sites
 const MASS_VACCINATION_SITES = [
     'Foxborough: Gillette Stadium',
-    'Boston: Fenway Park',
     'Danvers: Doubletree Hotel',
     'Springfield: Eastfield Mall',
     'Dartmouth: Former Circuit City', 


### PR DESCRIPTION
Per https://trello.com/c/GdRXFIko/108-remove-fenway-from-the-list-of-mass-vax-sites

### Test Plan:
Ensure the map loads as usual. Fenway was already deleted from the database, so it wasn't showing up anyway.