### PR TITLE
Reword "no availability" option.

### DIFF
--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -169,7 +169,7 @@ const SearchBar = (props) => {
                                     value={availability === AVAILABLE_ONLY}
                                     onChange={onChangeAvailability}
                                 />
-                                Show sites that don&apos;t have availability
+                                Include sites without availability
                             </label>
                         </div>
                     </div>


### PR DESCRIPTION
Per discussion here: https://vaccinatemaworkspace.slack.com/archives/C01L744H2DU/p1618404977017500

We're switching to “Include sites without availability” from “Show sites that don’t have availability”.

<img width="759" alt="Screen Shot 2021-04-16 at 4 24 53 PM" src="https://user-images.githubusercontent.com/8495791/115082128-61247780-9ed3-11eb-9879-dbc2b88ad2ce.png">
