### PR TITLE
On mobile, collapse the search bar on search.

### DIFF
--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -50,6 +50,7 @@ const SearchBar = (props) => {
             return;
         }
 
+        isMobile && setIsCollapsed(true);
         props.onSearch({address, availability, maxMiles});
     };
 
@@ -63,6 +64,7 @@ const SearchBar = (props) => {
                         timeout: 5000,
                     });
                 });
+                isMobile && setIsCollapsed(true);
                 props.onSearch({
                     latitude: position.coords.latitude,
                     longitude: position.coords.longitude,


### PR DESCRIPTION
Harlan asked that we collapse the search bar when a user completes a search on mobile.

### Test Plan:
* On desktop, ensure searching works as usual.
* On mobile, tap "search" and ensure the search bar collapses.