### PR TITLE
Use ResultsModal with Map view instead of plain popup

### DIFF
--- a/components/MapAndListView.js
+++ b/components/MapAndListView.js
@@ -53,19 +53,21 @@ const MapAndListView = (props) => {
                 </div>
                 {!showMap && <ListView rawSiteData={props.rawSiteData} />}
             </div>
-            {resultsModalData.data && <ResultsModal hideModal={() => setResultsModalData({})} data={{
-                id: resultsModalData.data.id,
-                name: resultsModalData.data.locationName,
-                address: resultsModalData.data.address,
-                serves: resultsModalData.data.populationsServed,
-                availability: resultsModalData.data.vaccineAvailability,
-                lastUpdated: resultsModalData.data.lastUpdated,
-                bookAppointmentInfo: resultsModalData.data.bookAppointmentInformation,
-                latitude: resultsModalData.data.latitude,
-                longitude: resultsModalData.data.longitude,
-                instructionsAtSite: 'TBD',
-            }}/>}
-            {console.log(resultsModalData)}
+            {resultsModalData.data && <ResultsModal 
+                hideModal={() => setResultsModalData({})}
+                data={{
+                    id: resultsModalData.data.id,
+                    locationName: resultsModalData.data.locationName,
+                    address: resultsModalData.data.address,
+                    populationsServed: resultsModalData.data.populationsServed,
+                    vaccineAvailability: resultsModalData.data.vaccineAvailability,
+                    lastUpdated: resultsModalData.data.lastUpdated,
+                    bookAppointmentInformation: resultsModalData.data.bookAppointmentInformation,
+                    latitude: resultsModalData.data.latitude,
+                    longitude: resultsModalData.data.longitude,
+                    instructionsAtSite: resultsModalData.data.instructionsAtSite,
+                    sitePinShape: resultsModalData.data.sitePinShape,
+                }}/>}
         </div>
     );
 };

--- a/components/MapAndListView.js
+++ b/components/MapAndListView.js
@@ -55,19 +55,7 @@ const MapAndListView = (props) => {
             </div>
             {resultsModalData.data && <ResultsModal 
                 hideModal={() => setResultsModalData({})}
-                data={{
-                    id: resultsModalData.data.id,
-                    locationName: resultsModalData.data.locationName,
-                    address: resultsModalData.data.address,
-                    populationsServed: resultsModalData.data.populationsServed,
-                    vaccineAvailability: resultsModalData.data.vaccineAvailability,
-                    lastUpdated: resultsModalData.data.lastUpdated,
-                    bookAppointmentInformation: resultsModalData.data.bookAppointmentInformation,
-                    latitude: resultsModalData.data.latitude,
-                    longitude: resultsModalData.data.longitude,
-                    instructionsAtSite: resultsModalData.data.instructionsAtSite,
-                    sitePinShape: resultsModalData.data.sitePinShape,
-                }}/>}
+                data={resultsModalData.data}/>}
         </div>
     );
 };

--- a/components/MapAndListView.js
+++ b/components/MapAndListView.js
@@ -5,9 +5,11 @@ import AvailabilityBanner from './subcomponents/AvailabilityBanner';
 import Button from './subcomponents/Button';
 import Map from './subcomponents/Map';
 import ListView from './subcomponents/ListView';
+import ResultsModal from './ResultsModal';
 
 const MapAndListView = (props) => {
     const [showMap, setShowMap] = useState(true);
+    const [resultsModalData, setResultsModalData] = useState({});
 
     const numAvailable = props.rawSiteData.filter(
         (site) => site.availability.length > 0
@@ -45,11 +47,25 @@ const MapAndListView = (props) => {
                         center={props.mapCoordinates}
                         zoom={props.mapZoom}
                         onMapChange={props.onMapChange}
+                        setPopupData={setResultsModalData}
                     />
                     <MapKey />
                 </div>
                 {!showMap && <ListView rawSiteData={props.rawSiteData} />}
             </div>
+            {resultsModalData.data && <ResultsModal hideModal={() => setResultsModalData({})} data={{
+                id: resultsModalData.data.id,
+                name: resultsModalData.data.locationName,
+                address: resultsModalData.data.address,
+                serves: resultsModalData.data.populationsServed,
+                availability: resultsModalData.data.vaccineAvailability,
+                lastUpdated: resultsModalData.data.lastUpdated,
+                bookAppointmentInfo: resultsModalData.data.bookAppointmentInformation,
+                latitude: resultsModalData.data.latitude,
+                longitude: resultsModalData.data.longitude,
+                instructionsAtSite: 'TBD',
+            }}/>}
+            {console.log(resultsModalData)}
         </div>
     );
 };

--- a/components/ResultsModal.js
+++ b/components/ResultsModal.js
@@ -3,7 +3,7 @@ import Map from './subcomponents/Map';
 import PropTypes from 'prop-types';
 import parseURLsInStrings from './utilities/parseURLsInStrings';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {faMapMarkerAlt} from '@fortawesome/free-solid-svg-icons';
+import {faMapMarkerAlt, faTimesCircle} from '@fortawesome/free-solid-svg-icons';
 
 const ResultsModal = ({data, hideModal}) => {
     useEffect(() => {
@@ -30,6 +30,13 @@ const ResultsModal = ({data, hideModal}) => {
                         setPopupData={() => {}}
                         onMapChange={() => {}}
                     />
+                </div>
+                <div>
+                    <center>
+                        <button onClick={hideModal}>
+                            <FontAwesomeIcon icon={faTimesCircle} />{" "} Close Modal
+                        </button>
+                    </center>
                 </div>
                 <div className="modal-site-name-section">
                     <div className="modal-section-content">

--- a/components/ResultsModal.js
+++ b/components/ResultsModal.js
@@ -34,7 +34,7 @@ const ResultsModal = ({data, hideModal}) => {
                 <div>
                     <center>
                         <button onClick={hideModal}>
-                            <FontAwesomeIcon icon={faTimesCircle} />{" "} Close Modal
+                            <FontAwesomeIcon icon={faTimesCircle} />{' '} Close Modal
                         </button>
                     </center>
                 </div>

--- a/components/ResultsModal.js
+++ b/components/ResultsModal.js
@@ -27,11 +27,13 @@ const ResultsModal = ({data, hideModal}) => {
                         rawSiteData={[data]}
                         center={{lat: data.latitude, lng: data.longitude}}
                         zoom={12}
+                        setPopupData={() => {}}
+                        onMapChange={() => {}}
                     />
                 </div>
                 <div className="modal-site-name-section">
                     <div className="modal-section-content">
-                        <h4>{data.name}</h4>
+                        <h4>{data.locationName}</h4>
                         <p className="modal-site-address-text">
                             {data.address}{' '}
                             <FontAwesomeIcon icon={faMapMarkerAlt} />{' '}
@@ -50,16 +52,16 @@ const ResultsModal = ({data, hideModal}) => {
                     <div className="modal-section-content">
                         <h3>To book an appointment</h3>
                         <p className="modal-book-appointment-text">
-                            {parseURLsInStrings(data.bookAppointmentInfo)}
+                            {parseURLsInStrings(data.bookAppointmentInformation)}
                         </p>
                     </div>
                 </div>
                 <div>
                     <div className="modal-section-content">
                         <p className="modal-section-header">Serves</p>
-                        <p className="modal-text">{data.serves}</p>
+                        <p className="modal-text">{data.populationsServed}</p>
                         <p className="modal-section-header">Availability</p>
-                        <p className="modal-text">{data.availability}</p>
+                        <p className="modal-text">{data.vaccineAvailability}</p>
                         <p className="modal-section-header">
                             Instructions at site
                         </p>
@@ -75,15 +77,16 @@ ResultsModal.propTypes = {
     hideModal: PropTypes.func.isRequired,
     data: PropTypes.shape({
         id: PropTypes.string.isRequired,
-        name: PropTypes.string.isRequired,
+        locationName: PropTypes.string.isRequired,
         address: PropTypes.string.isRequired,
-        serves: PropTypes.string.isRequired,
-        availability: PropTypes.string.isRequired,
+        populationsServed: PropTypes.string.isRequired,
+        vaccineAvailability: PropTypes.string.isRequired,
         lastUpdated: PropTypes.number.isRequired,
-        bookAppointmentInfo: PropTypes.string.isRequired,
+        bookAppointmentInformation: PropTypes.string.isRequired,
         latitude: PropTypes.number.isRequired,
         longitude: PropTypes.number.isRequired,
         instructionsAtSite: PropTypes.string.isRequired,
+        sitePinShape: PropTypes.string.isRequired,
     }).isRequired,
 };
 

--- a/components/subcomponents/Map.js
+++ b/components/subcomponents/Map.js
@@ -5,27 +5,8 @@ import GoogleMapReact from 'google-map-react';
 import parseURLsInStrings from '../utilities/parseURLsInStrings';
 import {dateToString} from '../utilities/date-utils';
 
-// High volume, large venue sites
-const MASS_VACCINATION_SITES = [
-    'Foxborough: Gillette Stadium',
-    'Danvers: Doubletree Hotel',
-    'Springfield: Eastfield Mall',
-    'Dartmouth: Former Circuit City', 
-    'Natick: Natick Mall',
-    'Boston: Reggie Lewis Center (Roxbury Community College)',
-    'Boston: Hynes Convention Center'
-];
-
-const ELIGIBLE_PEOPLE_STATEWIDE_TEXT = [
-    'All eligible people statewide',
-    'Eligible populations statewide'
-];
-
-const doesSiteServeAllEligiblePeopleStatewide = serves => ELIGIBLE_PEOPLE_STATEWIDE_TEXT.includes(serves?.trim());
-
-const isSiteAMassVaccinationSite = locationName => MASS_VACCINATION_SITES.includes(locationName);
-
 const parseLocationData = (data) => {
+    console.log(data);
     return data.map((site) => ({
         id: site.id,
         locationName: site.name,
@@ -39,22 +20,8 @@ const parseLocationData = (data) => {
         ),
         latitude: site.latitude,
         longitude: site.longitude,
-        sitePinShape: determineSitePinShape(
-            site.availability, site.serves, site.name,
-        ),
+        sitePinShape: site.sitePinShape,
     }));
-};
-
-const determineSitePinShape = (availability, serves, locationName) => {
-    if (!availability) {
-        return 'dot';
-    } else if (isSiteAMassVaccinationSite(locationName)) {
-        return 'star star-red';
-    } else if (doesSiteServeAllEligiblePeopleStatewide(serves)) {
-        return 'star star-green';
-    } else {
-        return 'star star-blue';
-    }
 };
 
 // google-map-react allows you to pass a "$hover" destructured prop if you want to have an effect on hover
@@ -193,6 +160,7 @@ Map.propTypes = {
             latitude: PropTypes.number,
             longitude: PropTypes.number,
             instructionsAtSite: PropTypes.string,
+            sitePinShape: PropTypes.string,
         })
     ),
     center: PropTypes.shape({
@@ -202,7 +170,7 @@ Map.propTypes = {
     zoom: PropTypes.number.isRequired,
     // ({center: {lat: number, lng: number}, zoom: number}) => void
     onMapChange: PropTypes.func.isRequired,
-    onMarkerClick: PropTypes.func,
+    setPopupData: PropTypes.func.isRequired,
 };
 
 export default Map;

--- a/components/subcomponents/Map.js
+++ b/components/subcomponents/Map.js
@@ -6,7 +6,6 @@ import parseURLsInStrings from '../utilities/parseURLsInStrings';
 import {dateToString} from '../utilities/date-utils';
 
 const parseLocationData = (data) => {
-    console.log(data);
     return data.map((site) => ({
         id: site.id,
         locationName: site.name,
@@ -55,46 +54,6 @@ Marker.propTypes = {
     sitePinShape: PropTypes.string,
     setPopupData: PropTypes.func,
     getSiteDataByKey: PropTypes.func,
-};
-
-const Popup = ({data, setPopupData}) => (
-    <div style={{
-        position: 'absolute',
-        transform: 'translate(0%, -50%)',
-        border: '1px solid black',
-        color: '#000000',
-        backgroundColor: '#FFFFFF',
-        width: '300px',
-        borderRadius: '5px',
-        boxShadow: '5px 5px',
-        padding: '5px'
-    }}>
-        <div id="content">
-            <h4 id="firstHeading" className="firstHeading">{data.locationName}</h4>
-            <div id="bodyContent">
-                <p><b>Details</b> {data.populationsServed}</p>
-                <p><b>Address</b> {data.address}</p>
-                <p><b>Availability</b> {data.vaccineAvailability || 'None'}</p>
-                <p>(Availability last updated {data.lastUpdated})</p>
-                <p><b>Make an appointment</b> {data.bookAppointmentInformation}</p>
-                <button onClick={() => setPopupData({})}>Close</button>
-            </div>
-        </div>
-    </div>
-);
-
-Popup.propTypes = {
-    data: PropTypes.shape(
-        {
-            locationName: PropTypes.string,
-            populationsServed: PropTypes.string,
-            address: PropTypes.string,
-            vaccineAvailability: PropTypes.string,
-            lastUpdated: PropTypes.string,
-            bookAppointmentInformation: PropTypes.array,
-        }
-    ),
-    setPopupData: PropTypes.func,
 };
 
 // TODO(hannah): These values were calculated by hand and assume the map is

--- a/components/subcomponents/Map.js
+++ b/components/subcomponents/Map.js
@@ -142,9 +142,8 @@ export const MAX_MILES_TO_ZOOM = {
     '25': 10,
 };
 
-const Map = ({rawSiteData, center, zoom, onMapChange}) => {
+const Map = ({rawSiteData, center, zoom, onMapChange, setPopupData}) => {
     const [siteData, setSiteData] = useState([]);
-    const [popupData, setPopupData] = useState({});
 
     const getSiteDataByKey = key => siteData.find(site => {
         return key === site.id;
@@ -176,12 +175,6 @@ const Map = ({rawSiteData, center, zoom, onMapChange}) => {
                         getSiteDataByKey={getSiteDataByKey}
                     />
                 ))}
-                {popupData.data && (<Popup
-                    lat={popupData.lat}
-                    lng={popupData.lng}
-                    data={popupData.data}
-                    setPopupData={setPopupData}
-                />)}
             </GoogleMapReact>
         </div>
     );
@@ -209,6 +202,7 @@ Map.propTypes = {
     zoom: PropTypes.number.isRequired,
     // ({center: {lat: number, lng: number}, zoom: number}) => void
     onMapChange: PropTypes.func.isRequired,
+    onMarkerClick: PropTypes.func,
 };
 
 export default Map;

--- a/utils/site-utils.js
+++ b/utils/site-utils.js
@@ -34,17 +34,22 @@ const getDataFromRecord = (record) => {
         fields['Availability'].trim().toLowerCase() != 'none'
             ? fields['Availability']
             : '';
+    const serves = fields['Serves'] || '';
+    const locationName = fields['Location Name'] || '';
     return {
         id: record.id,
-        name: fields['Location Name'] || '',
+        name: locationName,
         address: fields['Full Address'] || '',
-        serves: fields['Serves'] || '',
+        serves: serves,
         latitude: fields['Latitude'] || 0,
         longitude: fields['Longitude'] || 0,
         availability,
         lastUpdated: parseDate(fields['Last Updated']),
         bookAppointmentInfo: fields['Book an appointment'] || '',
-        instructionsAtSite: fields['Instructions at site'] || '',
+        instructionsAtSite: fields['Instructions at site'] || 'No specific instructions available',
+        sitePinShape: determineSitePinShape(
+            availability, serves, locationName,
+        ),
     };
 };
 
@@ -54,6 +59,39 @@ const parseDate = (dateString) => {
         return null;
     }
     return parsedDate;
+};
+
+// High volume, large venue sites
+const MASS_VACCINATION_SITES = [
+    'Foxborough: Gillette Stadium',
+    'Danvers: Doubletree Hotel',
+    'Springfield: Eastfield Mall',
+    'Dartmouth: Former Circuit City', 
+    'Natick: Natick Mall',
+    'Boston: Reggie Lewis Center (Roxbury Community College)',
+    'Boston: Hynes Convention Center'
+];
+
+const ELIGIBLE_PEOPLE_STATEWIDE_TEXT = [
+    'All eligible people statewide',
+    'Eligible populations statewide'
+];
+
+const doesSiteServeAllEligiblePeopleStatewide = serves => typeof(serves) == 'string' && ELIGIBLE_PEOPLE_STATEWIDE_TEXT.includes(serves.trim());
+
+const isSiteAMassVaccinationSite = locationName => MASS_VACCINATION_SITES.includes(locationName);
+
+
+const determineSitePinShape = (availability, serves, locationName) => {
+    if (!availability) {
+        return 'dot';
+    } else if (isSiteAMassVaccinationSite(locationName)) {
+        return 'star star-red';
+    } else if (doesSiteServeAllEligiblePeopleStatewide(serves)) {
+        return 'star star-green';
+    } else {
+        return 'star star-blue';
+    }
 };
 
 module.exports = {


### PR DESCRIPTION
Clicking on a pin on the map will bring up the ResultsModal instead of a popup within the map.

Usability notes:
- There is no visible way to close the modal; the user needs to know to click outside of the modal to close. Consider adding a visible way to close the modal.
- The modal is tall, particularly on smaller screens (my laptop is 1280x800 as a 13-inch Macbook Pro); the user needs to know to scroll wheel or two-finger touchpad scroll to view the entire modal. Consider making the modal wider, the font smaller, or other way of making the modal a manageable size.