### PR TITLE
Use static data for search functionality.

### DIFF
--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -9,7 +9,7 @@ export const ALL_AVAILABIITY = 'All known vaccination sites';
 const AVAILABLE_ONLY = 'Sites with reported doses';
 const MOBILE_WIDTH = 640;
 
-const MISSING_INFO_ERROR = 'Please enter a city, town, or ZIP.';
+const MISSING_INFO_ERROR = 'Please enter a valid ZIP code in MA.';
 const GEOLOCATION_ERROR = 'Cannot figure out your location.';
 
 const SearchBar = (props) => {
@@ -51,7 +51,12 @@ const SearchBar = (props) => {
         }
 
         isMobile && setIsCollapsed(true);
-        props.onSearch({address, availability, maxMiles});
+        try {
+            props.onSearch({address, availability, maxMiles});
+        } catch (err) {
+            setError(MISSING_INFO_ERROR);
+            console.error(err);
+        }
     };
 
     const searchByGeolocation = async () => {
@@ -137,7 +142,7 @@ const SearchBar = (props) => {
                     same line while resizing.*/}
                     <div className="search-header-section">
                         <div className="search-header-col">
-                            <p>City, Town, or ZIP</p>
+                            <p>ZIP Code</p>
                             <input
                                 type="text"
                                 id="address"

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,14 @@
 import React, {useEffect, useState} from 'react';
 
-import PreregisterBanner from '../components/PreregisterBanner';
+import {getClosestLocations} from '../utils/distance-utils';
+import {MAX_MILES_TO_ZOOM} from '../components/subcomponents/Map';
 import Layout from '../components/Layout';
 import MapAndListView from '../components/MapAndListView';
+import PreregisterBanner from '../components/PreregisterBanner';
 import SearchBar, {ALL_AVAILABIITY} from '../components/SearchBar';
-import {MAX_MILES_TO_ZOOM} from '../components/subcomponents/Map';
+
+const SITES = require('../static/sites.json');
+const ZIP_CODES = require('../static/zip-codes.json');
 
 const DEFAULT_ZOOMED_OUT = 8;
 const DEFAULT_ZOOMED_IN = 9;
@@ -28,17 +32,28 @@ const Home = () => {
         setMapCoordinates(BOSTON_COORDINATES);
         setMapZoom(DEFAULT_ZOOMED_OUT);
 
-        const sites = require('../static/sites.json');
-
         // TODO(hannah): Currently, in list view, the sites are just listed
         // alphabetically. Per discussions with Harlan, we should be sorting
         // them some more useful way.
         if (includeUnavailable) {
-            setRawSiteData(sites);
+            setRawSiteData(SITES);
             return;
         }
 
-        setRawSiteData(sites.filter((site) => site.availability.length > 0));
+        setRawSiteData(SITES.filter((site) => site.availability.length > 0));
+    };
+
+    const getLatLngForSearch = (args) => {
+        if (args.address) {
+            if (ZIP_CODES[args.address]) {
+                return ZIP_CODES[args.address];
+            }
+            throw 'Invalid ZIP code.';
+        }
+        if (args.latitude && args.longitude) {
+            return {lat: args.latitude, lng: args.longitude};
+        }
+        throw 'Insufficient location information.';
     };
 
     const onSearch = (args) => {
@@ -48,24 +63,23 @@ const Home = () => {
             });
         }
 
-        return fetch('/search_query_location', {
-            method: 'post',
-            headers: new Headers({'content-type': 'application/json'}),
-            body: JSON.stringify({...args}),
-        })
-            .then((response) => response.json())
-            .then((response) => {
-                const {lat, lng, siteData} = response;
-                setRawSiteData(siteData);
-                setMapCoordinates({lat, lng});
-                setMapZoom(
-                    MAX_MILES_TO_ZOOM[args.maxMiles] || DEFAULT_ZOOMED_IN
-                );
-            })
-            .catch((error) => {
-                // TODO(hannah): Add better error handling.
-                console.log(error);
-            });
+        var locations = [];
+        if (args.availability === 'Sites with reported doses') {
+            locations = SITES.filter((site) => site.availability.length > 0);
+        } else {
+            locations = SITES;
+        }
+
+        const {lat, lng} = getLatLngForSearch(args);
+        const siteData = getClosestLocations(
+            locations,
+            lat,
+            lng,
+            args.maxMiles
+        );
+        setRawSiteData(siteData);
+        setMapCoordinates({lat, lng});
+        setMapZoom(MAX_MILES_TO_ZOOM[args.maxMiles] || DEFAULT_ZOOMED_IN);
     };
 
     const onMapChange = ({center, zoom}) => {


### PR DESCRIPTION
This PR switches to using static data for the search functionality. So that we don't have to rely on Google Geocoder or Pelias, I also switched us back to only supporting MA ZIP codes. (The static mapping between MA ZIP codes and latitude / longitudes already exists.)

### Test Plan:
* Ensure search functionality works as usual for ZIP codes in MA.
* Ensure an error is displayed if anything other than an MA ZIP code is entered.